### PR TITLE
EI-496 - Twin visibility deprecation

### DIFF
--- a/proto/iotics/api/feed.proto
+++ b/proto/iotics/api/feed.proto
@@ -24,6 +24,7 @@ option php_namespace = "Iotics\\Api";
 // A feed generates data in a 1-to-many relationship: one feed may produce data that is used by many consumers (twins).
 service FeedAPI {
   // Creates a feed owned by a twin. (Idempotent)
+  // Deprecation: CreateFeedRequest.payload.storeLast is no longer used. Please use UpdateFeed or UpsertTwin to set feed storeLast value.
   rpc CreateFeed(CreateFeedRequest) returns (CreateFeedResponse) {}
 
   // Deletes a feed owned by a twin. (Idempotent)
@@ -51,12 +52,14 @@ message Feed {
 }
 
 // CreateFeedRequestCreate is used to create a new feed in a given twin.
+// Deprecation: CreateFeedRequest.payload.storeLast is no longer used. Please use UpdateFeed or UpsertTwin to set feed storeLast value.
 message CreateFeedRequest {
   // Payload describes the data needed to create a feed.
   message Payload {
     // ID of the feed to create
     FeedID feedId = 1;
     // StoreLast indicates if the last received value should be stored of not
+    // Deprecated: storeLast can be set using UpdateFeedRequest or UpsertFeedWithMeta
     bool storeLast = 2;
   }
   // Arguments describes the mandatory arguments to identify the twin the feed belongs to.

--- a/proto/iotics/api/feed.proto
+++ b/proto/iotics/api/feed.proto
@@ -25,6 +25,7 @@ option php_namespace = "Iotics\\Api";
 service FeedAPI {
   // Creates a feed owned by a twin. (Idempotent)
   // Deprecation: CreateFeedRequest.payload.storeLast is no longer used. Please use UpdateFeed or UpsertTwin to set feed storeLast value.
+  // Deprecation: CreateFeedResponse.payload.alreadyCreated is no longer set (the service remains idempotent).
   rpc CreateFeed(CreateFeedRequest) returns (CreateFeedResponse) {}
 
   // Deletes a feed owned by a twin. (Idempotent)
@@ -77,12 +78,14 @@ message CreateFeedRequest {
 }
 
 // CreateFeedResponse describes a created feed.
+// Deprecation: CreateFeedResponse.payload.alreadyCreated is no longer set (the service remains idempotent).
 message CreateFeedResponse {
   // CreateFeedResponse payload.
   message Payload {
     // The created feed
     Feed feed = 1;
     // AlreadyCreated indicates if the feed already existed (the create is idempotent)
+    // Deprecated: no longer set
     bool alreadyCreated = 2;
   }
   // CreateFeedResponse headers

--- a/proto/iotics/api/twin.proto
+++ b/proto/iotics/api/twin.proto
@@ -26,6 +26,7 @@ service TwinAPI {
   // CreateTwin creates a twin.
   // Deprecation: CreateTwinResponse.payload.twin.visibility is no longer set.
   // The twin visibility can be obtained through a call to DescribeTwin.
+  // Deprecation: CreateTwinResponse.payload.alreadyCreated is no longer set (the service remains idempotent).
   rpc CreateTwin(CreateTwinRequest) returns (CreateTwinResponse) {}
 
   // UpsertTwin creates or update a twin with its metadata + the twin feeds with their metadata.
@@ -113,6 +114,7 @@ message CreateTwinRequest {
 // CreateTwinResponse is received when a twin has been created.
 // Deprecation: resp.payload.twin.visibility is no longer set.
 // The twin visibility can be obtained through a call to DescribeTwin.
+// Deprecation: resp.payload.alreadyCreated is no longer set (the service remains idempotent).
 message CreateTwinResponse {
 
   // Payload identifies the twin which was created.
@@ -121,6 +123,7 @@ message CreateTwinResponse {
     Twin twin = 1;
 
     // whether the twin exists already (creating an existing twin is idempotent). Optional, with default=false.
+    // Deprecated: no longer set
     bool alreadyCreated = 2;
   }
 

--- a/proto/iotics/api/twin.proto
+++ b/proto/iotics/api/twin.proto
@@ -24,6 +24,8 @@ option php_namespace = "Iotics\\Api";
 service TwinAPI {
 
   // CreateTwin creates a twin.
+  // Deprecation: CreateTwinResponse.payload.twin.visibility is no longer set.
+  // The twin visibility can be obtained through a call to DescribeTwin.
   rpc CreateTwin(CreateTwinRequest) returns (CreateTwinResponse) {}
 
   // UpsertTwin creates or update a twin with its metadata + the twin feeds with their metadata.
@@ -32,9 +34,13 @@ service TwinAPI {
   rpc UpsertTwin(UpsertTwinRequest) returns (UpsertTwinResponse) {}
 
   // DeleteTwin deletes a twin.
+  // Deprecation: DeleteTwinResponse.payload.twin.visibility is no longer set.
+  // The twin visibility can be obtained through a call to DescribeTwin.
   rpc DeleteTwin(DeleteTwinRequest) returns (DeleteTwinResponse) {}
 
   // UpdateTwin updates a twin (partial update).
+  // Deprecation: UpdateTwinResponse.payload.twin.visibility is no longer set.
+  // The twin visibility can be obtained through a call to DescribeTwin.
   rpc UpdateTwin(UpdateTwinRequest) returns (UpdateTwinResponse) {}
 
   // Describes a twin.
@@ -52,6 +58,7 @@ message Twin {
   TwinID id = 1;
 
   // Visibility of this twin
+  // Deprecated: the field is no longer set except for DescribeTwinResponse and ListAllTwinsResponse
   Visibility visibility = 2;
 }
 
@@ -104,6 +111,8 @@ message CreateTwinRequest {
 }
 
 // CreateTwinResponse is received when a twin has been created.
+// Deprecation: resp.payload.twin.visibility is no longer set.
+// The twin visibility can be obtained through a call to DescribeTwin.
 message CreateTwinResponse {
 
   // Payload identifies the twin which was created.
@@ -141,6 +150,8 @@ message DeleteTwinRequest {
 }
 
 // Deleted is received when a twin has been deleted.
+// Deprecation: resp.payload.twin.visibility is no longer set.
+// The twin visibility can be obtained through a call to DescribeTwin.
 message DeleteTwinResponse {
 
   // Payload identifies the twin which was deleted.
@@ -290,6 +301,8 @@ message UpdateTwinRequest {
 
 
 // UpdateTwinResponse describes an updated twin. It is received when the update operation is successful.
+// Deprecation: resp.payload.twin.visibility is no longer set.
+// The twin visibility can be obtained through a call to DescribeTwin.
 message UpdateTwinResponse {
   // UpdateTwinResponse payload.
   message Payload {


### PR DESCRIPTION
Twin visibility field is no longer set in the response payload of the following services:
* CreateTwin
* DeleteTwin
* UpdateTwin
* ListAllTwins

The twin visibility can be obtained through a call to DescribeTwin.