### PR TITLE
EI-441 - Remove explicit twin tags, labels & comments

### DIFF
--- a/proto/iotics/api/common.proto
+++ b/proto/iotics/api/common.proto
@@ -49,7 +49,6 @@ message LangLiteral {
   // String representation of the value
   string value = 2;
 }
-
 // StringLiteral is a metadata property type describing a string without a language (implicit datatype: rdf:string).
 message StringLiteral {
   // String representation of the value
@@ -110,24 +109,6 @@ message GeoCircle {
   double radiusKm = 2;
 }
 
-// LabelUpdate describes labels metadata property update: addition and deletion of labels with language.
-message LabelUpdate {
-  // List of labels to be added. (Note: Only one label per language is stored, i.e. any existing ones with the same
-  // language will be replaced.)
-  repeated LangLiteral added = 1;
-  // List of languages for which to remove labels
-  repeated string deletedByLang = 2;
-}
-
-// CommentUpdate describes comments metadata property update: addition and deletion of comments with language.
-message CommentUpdate {
-  // List of labels to be added. (Note: Only one comment per language is stored, i.e. any existing ones with the same
-  // language will be replaced.)
-  repeated LangLiteral added = 1;
-  // List of languages for which to remove comments
-  repeated string deletedByLang = 2;
-}
-
 // Visibility defines who a twin is visible to.
 // PRIVATE - the twin is only visible in a LOCAL scope.
 // PUBLIC - the twin is visible in any scope.
@@ -142,15 +123,6 @@ enum Visibility {
 enum Scope {
   GLOBAL = 0;
   LOCAL = 1;
-}
-
-// Tags describes tags metadata property update: list of tags to be added and deleted. if a tag appears in both lists,
-// applications may choose to ignore the tags or throw some error.
-message Tags {
-  // List of tags to be added
-  repeated string added = 1;
-  // List of tags to be deleted
-  repeated string deleted = 2;
 }
 
 // Headers describes the common headers applicable to all the API requests

--- a/proto/iotics/api/feed.proto
+++ b/proto/iotics/api/feed.proto
@@ -128,14 +128,8 @@ message UpdateFeedRequest {
 
     // storeLast dictates whether to store the last shared sample of a feed.
     google.protobuf.BoolValue storeLast = 1;
-    // tags are the set of tags to add or remove.
-    Tags tags = 2;
     // values are descriptive individual data items to add/remove.
     Values values = 3;
-    // labels are human-readable set of labels (language-specific) to add or remove.
-    LabelUpdate labels = 4;
-    // comments are the human-readable extended descriptions (language-specific) to add or remove.
-    CommentUpdate comments = 5;
   }
 
   // UpdateFeedRequest arguments.
@@ -237,9 +231,6 @@ message DescribeFeedRequest {
     HostID remoteHostId = 2;
   }
   Headers headers = 1;
-  // Language code for labels and comments. If set, only the label and comment in the given language will be returned
-  // instead of all. This field does not apply to values and tags which are always returned in full.
-  google.protobuf.StringValue lang = 2;
   // DescribeFeedRequest mandatory arguments
   Arguments args = 3;
 }
@@ -250,15 +241,8 @@ message DescribeFeedResponse {
 
   // Metadata result databag.
   message MetaResult {
-    // Labels in all languages set for the feed. (Or: Only label in chosen language, if lang field was specified in the
-    // request.)
-    repeated LangLiteral labels = 1;
     // values semantically describing the share payload of Feed or expected arguments for a Control request
     repeated Value values = 2;
-    repeated string tags = 3;
-    // Comments in all languages set for the feed. (Or: Only comment in chosen language, if lang field was specified in
-    // the request.)
-    repeated LangLiteral comments = 4;
     // Whether this feed might have its most recent data sample stored. If so, it can be retrieved via FetchLastStored
     // request. (See interest API)
     bool storeLast = 5;
@@ -277,12 +261,6 @@ message DescribeFeedResponse {
 message UpsertFeedWithMeta {
   // Id of the feed to create/update
   string id = 1;
-
-  // Labels are human-readable set of labels (language-specific) to set
-  repeated LangLiteral labels = 2;
-
-  // Comments are human-readable set of labels (language-specific) to set
-  repeated LangLiteral comments = 3;
 
   // storeLast dictates whether to store the last shared sample of the feed. Default 'False'
   bool storeLast = 4;

--- a/proto/iotics/api/search.proto
+++ b/proto/iotics/api/search.proto
@@ -54,8 +54,8 @@ message SearchRequest {
 
     // Search request filters, any of these can be used in combination or on their own.
     message Filter {
-      // Text filtering. One or more keywords which must match either text from twin/feed labels/comments (in the given
-      // language). Note that any (rather than all) of the keywords will produce a match.
+      // Text filtering. One or more keywords which must match text from twin properies. Note that any (rather than all)
+      // of the keywords will produce a match.
       google.protobuf.StringValue text = 1;
       // Location filtering: area within which twins must be located
       GeoCircle location = 2;
@@ -71,7 +71,7 @@ message SearchRequest {
   // Search request scope
   Scope scope = 2;
 
-  // Search request lang. It implies both search and result text language
+  // Search request language, applicable to text filtering. If not specified, text search will match any language.
   google.protobuf.StringValue lang = 3;
 
   // Search request payload
@@ -92,8 +92,6 @@ message SearchResponse {
   message FeedDetails {
     // Feed
     Feed feed = 1;
-    // The feed human readable label in the language specified in the request (if set)
-    string label = 2;
     // whether offers the ability to store last received value
     bool storeLast = 3;
   }
@@ -104,10 +102,6 @@ message SearchResponse {
     TwinID id = 1;
     // Twin location (if set). Included with response type: FULL and LOCATED
     GeoLocation location = 2;
-    // Twin human readable label in the language specified in the request (if set). Included with response type: FULL and LOCATED
-    string label = 3;
-    // Twin tags. Included with response type: FULL
-    repeated string tags = 4;
     // Twin custom properties. Does not include labels/comments/location. Included with response type: FULL
     repeated Property properties = 5;
     // Feed details. Included with response type: FULL

--- a/proto/iotics/api/twin.proto
+++ b/proto/iotics/api/twin.proto
@@ -169,17 +169,12 @@ message DescribeTwinRequest {
 
   Headers headers = 1;
 
-  // Language code for labels and comments. If set, only the label and comment in the given language will be returned
-  // instead of all. This field does not apply to tags and properties which are always returend in full.
-  google.protobuf.StringValue lang = 2;
-
   Arguments args = 3;
 }
 
 // Metadata message for this Feed.
 message FeedMeta {
   FeedID feedId = 1;
-  repeated LangLiteral labels = 2;
   bool storeLast = 3;
 }
 
@@ -191,14 +186,7 @@ message DescribeTwinResponse {
   // Metadata result data bag for this feed.
   message MetaResult {
     GeoLocation location = 1;
-    // Labels in all languages set for the twin. (Or: Only label in chosen language, if lang field was specified in
-    // the request.)
-    repeated LangLiteral labels = 2;
-    // Comments in all languages set for the twin. (Or: Only comment in chosen language, if lang field was specified
-    // in the request.)
-    repeated LangLiteral comments = 3;
     repeated FeedMeta feeds = 4;
-    repeated string tags = 5;
     // Custom properties associated with this twin. Does not include labels/comments/location.
     repeated Property properties = 6;
   }
@@ -260,20 +248,11 @@ message UpdateTwinRequest {
   // Note that the specified metadata changes are applied in the following order:
   // tags, visibility, properties, labels, comments, location
   message Payload {
-    // Tags are the set of tags to add or remove.
-    Tags tags = 1;
-
     // New visibility
     VisibilityUpdate newVisibility = 2;
 
     // Custom properties to add/remove. Internal properties (such as location) cannot be modified here.
     PropertyUpdate properties = 3;
-
-    // Labels are human-readable set of labels (language-specific) to add or remove.
-    LabelUpdate labels = 4;
-
-    // Comments are the human-readable extended descriptions (language-specific) to add or remove.
-    CommentUpdate comments = 5;
 
     // Location to be set/unset
     GeoLocationUpdate location = 6;
@@ -313,12 +292,6 @@ message UpsertTwinRequest {
 
     // Twin visibility. Default value: 'PRIVATE'
     Visibility visibility = 2;
-
-    // Labels are human-readable set of labels (language-specific) to set
-    repeated LangLiteral labels = 3;
-
-    // Comments are human-readable set of labels (language-specific) to set
-    repeated LangLiteral comments = 4;
 
     // Twin Properties to set
     repeated Property properties = 5;


### PR DESCRIPTION
Keeping as draft until rest of removal nears completion

---

- Twin & Feed tags removed
- Twin & Feed labels & comments removed