### PR TITLE
EI-440: Feed - properties crud

### DIFF
--- a/proto/iotics/api/common.proto
+++ b/proto/iotics/api/common.proto
@@ -111,6 +111,7 @@ message GeoCircle {
 }
 
 // LabelUpdate describes labels metadata property update: addition and deletion of labels with language.
+// DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
 message LabelUpdate {
   // List of labels to be added. (Note: Only one label per language is stored, i.e. any existing ones with the same
   // language will be replaced.)
@@ -120,6 +121,7 @@ message LabelUpdate {
 }
 
 // CommentUpdate describes comments metadata property update: addition and deletion of comments with language.
+// DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
 message CommentUpdate {
   // List of labels to be added. (Note: Only one comment per language is stored, i.e. any existing ones with the same
   // language will be replaced.)
@@ -146,6 +148,7 @@ enum Scope {
 
 // Tags describes tags metadata property update: list of tags to be added and deleted. if a tag appears in both lists,
 // applications may choose to ignore the tags or throw some error.
+// DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
 message Tags {
   // List of tags to be added
   repeated string added = 1;

--- a/proto/iotics/api/feed.proto
+++ b/proto/iotics/api/feed.proto
@@ -126,6 +126,24 @@ message DeleteFeedResponse {
 
 // UpdateFeedRequest is used to update attributes (including metadata) of a given feed.
 message UpdateFeedRequest {
+  // Soft breaking change: move to common once ready for real breaking change
+
+  // PropertyUpdate describes the update of feed properties.
+  // Can be used to add, replace, or delete properties. The order of operations is:
+  // clearedAll (if True), deleted, deletedByKey, added.
+  // Note that internal properties (such as location) cannot be modified here.
+  message PropertyUpdate {
+
+    // Delete all properties currently set on the twin.
+    bool clearedAll = 1;
+
+    // Delete specific exact properties (by key and value). This operation is ignored if clearAll is True.
+    repeated Property deleted = 2;
+    // Delete any properties with the given keys (predicates). This operation is ignored if clearAll is True.
+    repeated string deletedByKey = 3;
+    // Adds the given properties
+    repeated Property added = 4;
+  }
 
   // UpdateFeedRequest payload. One or more fields can be provided, depending on what needs to be updated.
   // Note that the specified metadata changes are applied in the following order:
@@ -142,6 +160,8 @@ message UpdateFeedRequest {
     LabelUpdate labels = 4;
     // comments are the human-readable extended descriptions (language-specific) to add or remove.
     CommentUpdate comments = 5;
+    // Custom properties to add/remove. Internal properties (such as location) cannot be modified here.
+    PropertyUpdate properties = 6;
   }
 
   // UpdateFeedRequest arguments.
@@ -268,6 +288,9 @@ message DescribeFeedResponse {
     // Whether this feed might have its most recent data sample stored. If so, it can be retrieved via FetchLastStored
     // request. (See interest API)
     bool storeLast = 5;
+
+    // Custom properties associated with this feed.
+    repeated Property properties = 6;
   }
 
   // DescribeFeedResponse payload.
@@ -295,4 +318,7 @@ message UpsertFeedWithMeta {
 
   // values to set
   repeated Value values = 5;
+
+  // feed properties to set
+  repeated Property properties = 6;
 }

--- a/proto/iotics/api/feed.proto
+++ b/proto/iotics/api/feed.proto
@@ -32,6 +32,7 @@ service FeedAPI {
   rpc DeleteFeed(DeleteFeedRequest) returns (DeleteFeedResponse) {}
 
   // Updates attributes of a feed, including its metadata.
+  // Deprecation: tags, labels and comments are now ignored and will be removed as part of the next major release.
   rpc UpdateFeed(UpdateFeedRequest) returns (UpdateFeedResponse) {}
 
   // Shares a new sample of data for the given feed which any (interest) subscribers can receive.
@@ -41,6 +42,8 @@ service FeedAPI {
   rpc ListAllFeeds(ListAllFeedsRequest) returns (ListAllFeedsResponse) {}
 
   // Describe feed.
+  // Deprecation: lang filter request field is now ignored.
+  // Deprecation: tags, labels and comments response fields are no longer returned.
   rpc DescribeFeed(DescribeFeedRequest) returns (DescribeFeedResponse) {}
 }
 
@@ -125,6 +128,7 @@ message DeleteFeedResponse {
 // ---------------------------------------
 
 // UpdateFeedRequest is used to update attributes (including metadata) of a given feed.
+// Deprecation: tags, labels and comments are now ignored and will be removed as part of the next major release.
 message UpdateFeedRequest {
   // Soft breaking change: move to common once ready for real breaking change
 
@@ -153,12 +157,17 @@ message UpdateFeedRequest {
     // storeLast dictates whether to store the last shared sample of a feed.
     google.protobuf.BoolValue storeLast = 1;
     // tags are the set of tags to add or remove.
+    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
     Tags tags = 2;
     // values are descriptive individual data items to add/remove.
     Values values = 3;
     // labels are human-readable set of labels (language-specific) to add or remove.
+    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
+    // Labels can be added as regular properties.
     LabelUpdate labels = 4;
     // comments are the human-readable extended descriptions (language-specific) to add or remove.
+    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
+    // Comment can be added as regular properties.
     CommentUpdate comments = 5;
     // Custom properties to add/remove. Internal properties (such as location) cannot be modified here.
     PropertyUpdate properties = 6;
@@ -252,6 +261,7 @@ message ListAllFeedsResponse {
 }
 
 // Description of twin: Provides public metadata lookup for individual resources.
+// Deprecation: lang filter request field is now ignored.
 message DescribeFeedRequest {
 
   // Only one action argument is necessary.
@@ -265,11 +275,13 @@ message DescribeFeedRequest {
   Headers headers = 1;
   // Language code for labels and comments. If set, only the label and comment in the given language will be returned
   // instead of all. This field does not apply to values and tags which are always returned in full.
+  // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
   google.protobuf.StringValue lang = 2;
   // DescribeFeedRequest mandatory arguments
   Arguments args = 3;
 }
 // Describe feed response.
+// Deprecation: tags, labels and comments response fields are no longer returned.
 message DescribeFeedResponse {
   Headers headers = 1;
 
@@ -278,12 +290,17 @@ message DescribeFeedResponse {
   message MetaResult {
     // Labels in all languages set for the feed. (Or: Only label in chosen language, if lang field was specified in the
     // request.)
+    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
+    // Labels are no longer special properties.
     repeated LangLiteral labels = 1;
     // values semantically describing the share payload of Feed or expected arguments for a Control request
     repeated Value values = 2;
+    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
     repeated string tags = 3;
     // Comments in all languages set for the feed. (Or: Only comment in chosen language, if lang field was specified in
     // the request.)
+    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
+    // Comments are no longer special properties
     repeated LangLiteral comments = 4;
     // Whether this feed might have its most recent data sample stored. If so, it can be retrieved via FetchLastStored
     // request. (See interest API)
@@ -308,9 +325,13 @@ message UpsertFeedWithMeta {
   string id = 1;
 
   // Labels are human-readable set of labels (language-specific) to set
+  // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
+  // Labels can be added as regular properties.
   repeated LangLiteral labels = 2;
 
   // Comments are human-readable set of labels (language-specific) to set
+  // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
+  // Comments can be added as regular properties.
   repeated LangLiteral comments = 3;
 
   // storeLast dictates whether to store the last shared sample of the feed. Default 'False'

--- a/proto/iotics/api/search.proto
+++ b/proto/iotics/api/search.proto
@@ -24,12 +24,16 @@ option php_namespace = "Iotics\\Api";
 // SearchAPI provides a set of services to run synchronous and asynchronous search.
 service SearchAPI {
   // Send a search request. Results are expected asynchronously.
+  // Deprecation: search by text is now applied to twin rdfs:comment/rdfs:label instead of iotics:label/iotics:comments.
   rpc DispatchSearchRequest(SearchRequest) returns (DispatchSearchResponse) {}
 
   // Run a synchronous search based on a user timeout.
+  // Deprecation: search by text is now applied to twin rdfs:comment/rdfs:label instead of iotics:label/iotics:comments.
+  // Deprecation: tags and labels response fields are no longer returned.
   rpc SynchronousSearch(SearchRequest) returns (stream SearchResponse) {}
 
   // Receive all search responses associated to a set of Search request for a given client application ID.
+  // Deprecation: tags and labels response fields are no longer returned.
   rpc ReceiveAllSearchResponses(SubscriptionHeaders) returns (stream SearchResponse) {}
 }
 
@@ -44,6 +48,7 @@ enum ResponseType {
 }
 
 // SearchRequest describes a search request used for both synchronous and asynchronous search.
+// Deprecation: search by text is now applied to twin rdfs:comment/rdfs:label instead of iotics:label/iotics:comments.
 message SearchRequest {
   // Search request payload.
   message Payload {
@@ -54,8 +59,8 @@ message SearchRequest {
 
     // Search request filters, any of these can be used in combination or on their own.
     message Filter {
-      // Text filtering. One or more keywords which must match either text from twin/feed labels/comments (in the given
-      // language). Note that any (rather than all) of the keywords will produce a match.
+      // Text filtering. One or more keywords which must match text from twin properies. Note that any (rather than all)
+      // of the keywords will produce a match.
       google.protobuf.StringValue text = 1;
       // Location filtering: area within which twins must be located
       GeoCircle location = 2;
@@ -71,7 +76,7 @@ message SearchRequest {
   // Search request scope
   Scope scope = 2;
 
-  // Search request lang. It implies both search and result text language
+  // Search request language, applicable to text filtering. If not specified, text search will match any language.
   google.protobuf.StringValue lang = 3;
 
   // Search request payload
@@ -87,12 +92,14 @@ message SearchRequest {
 // It contains all the matching twins/feeds according to the request scope/range/lang/filters in the expected response type format.
 // In the decentralised iotics operating environment, each node in the network generates a response and the client is expected to
 // receive a stream of response messages.
+// Deprecation: tags and labels response fields are no longer returned.
 message SearchResponse {
   // Search response feed details. Included with response type: FULL.
   message FeedDetails {
     // Feed
     Feed feed = 1;
     // The feed human readable label in the language specified in the request (if set)
+    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
     string label = 2;
     // whether offers the ability to store last received value
     bool storeLast = 3;
@@ -108,8 +115,10 @@ message SearchResponse {
     // Twin location (if set). Included with response type: FULL and LOCATED
     GeoLocation location = 2;
     // Twin human readable label in the language specified in the request (if set). Included with response type: FULL and LOCATED
+    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
     string label = 3;
     // Twin tags. Included with response type: FULL
+    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
     repeated string tags = 4;
     // Twin custom properties.
     repeated Property properties = 5;

--- a/proto/iotics/api/search.proto
+++ b/proto/iotics/api/search.proto
@@ -96,6 +96,9 @@ message SearchResponse {
     string label = 2;
     // whether offers the ability to store last received value
     bool storeLast = 3;
+    // Feed custom properties.
+    repeated Property properties = 4;
+
   }
 
   // Search response twin details.
@@ -108,7 +111,7 @@ message SearchResponse {
     string label = 3;
     // Twin tags. Included with response type: FULL
     repeated string tags = 4;
-    // Twin custom properties. Does not include labels/comments/location. Included with response type: FULL
+    // Twin custom properties.
     repeated Property properties = 5;
     // Feed details. Included with response type: FULL
     repeated FeedDetails feeds = 10;

--- a/proto/iotics/api/twin.proto
+++ b/proto/iotics/api/twin.proto
@@ -213,7 +213,7 @@ message DescribeTwinResponse {
     repeated LangLiteral comments = 3;
     repeated FeedMeta feeds = 4;
     repeated string tags = 5;
-    // Custom properties associated with this twin. Does not include labels/comments/location.
+    // Custom properties associated with this twin.
     repeated Property properties = 6;
   }
 

--- a/proto/iotics/api/twin.proto
+++ b/proto/iotics/api/twin.proto
@@ -32,6 +32,7 @@ service TwinAPI {
   // UpsertTwin creates or update a twin with its metadata + the twin feeds with their metadata.
   // The full state is applied (ie. if the operation succeeds the state of the twin/feeds will be the one
   // described in the payload)
+  // Deprecation: twin/feed labels and comments are now ignored and will be removed as part of the next major release.
   rpc UpsertTwin(UpsertTwinRequest) returns (UpsertTwinResponse) {}
 
   // DeleteTwin deletes a twin.
@@ -42,9 +43,12 @@ service TwinAPI {
   // UpdateTwin updates a twin (partial update).
   // Deprecation: UpdateTwinResponse.payload.twin.visibility is no longer set.
   // The twin visibility can be obtained through a call to DescribeTwin.
+  // Deprecation: tags, labels and comments are now ignored and will be removed as part of the next major release.
   rpc UpdateTwin(UpdateTwinRequest) returns (UpdateTwinResponse) {}
 
   // Describes a twin.
+  // Deprecation: lang filter request field is now ignored.
+  // Deprecation: tags, labels and comments response fields are no longer returned.
   rpc DescribeTwin(DescribeTwinRequest) returns (DescribeTwinResponse) {}
 
   // List all twins.
@@ -171,6 +175,7 @@ message DeleteTwinResponse {
 }
 
 // Description of twin: Provides public metadata lookup for individual resources.
+// Deprecation: lang filter request field is now ignored.
 message DescribeTwinRequest {
   // Only one action argument is necessary.
   message Arguments {
@@ -184,7 +189,8 @@ message DescribeTwinRequest {
   Headers headers = 1;
 
   // Language code for labels and comments. If set, only the label and comment in the given language will be returned
-  // instead of all. This field does not apply to tags and properties which are always returend in full.
+  // instead of all. This field does not apply to tags and properties which are always returned in full.
+  // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
   google.protobuf.StringValue lang = 2;
 
   Arguments args = 3;
@@ -198,6 +204,7 @@ message FeedMeta {
 }
 
 // The response for a description request on this twin.
+// Deprecation: tags, labels and comments response fields are no longer returned.
 message DescribeTwinResponse {
   Headers headers = 1;
 
@@ -207,11 +214,16 @@ message DescribeTwinResponse {
     GeoLocation location = 1;
     // Labels in all languages set for the twin. (Or: Only label in chosen language, if lang field was specified in
     // the request.)
+    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
+    // Labels are no longer special properties.
     repeated LangLiteral labels = 2;
     // Comments in all languages set for the twin. (Or: Only comment in chosen language, if lang field was specified
     // in the request.)
+    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
+    // Comments are no longer special properties
     repeated LangLiteral comments = 3;
     repeated FeedMeta feeds = 4;
+    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
     repeated string tags = 5;
     // Custom properties associated with this twin.
     repeated Property properties = 6;
@@ -264,6 +276,7 @@ message GeoLocationUpdate {
 }
 
 // UpdateTwinRequest is used to update attributes (including metadata) of a given twin.
+// Deprecation: tags, labels and comments are now ignored and will be removed as part of the next major release.
 message UpdateTwinRequest {
   // UpdateTwinRequest mandatory arguments.
   message Arguments {
@@ -275,6 +288,7 @@ message UpdateTwinRequest {
   // tags, visibility, properties, labels, comments, location
   message Payload {
     // Tags are the set of tags to add or remove.
+    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
     Tags tags = 1;
 
     // New visibility
@@ -284,9 +298,13 @@ message UpdateTwinRequest {
     PropertyUpdate properties = 3;
 
     // Labels are human-readable set of labels (language-specific) to add or remove.
+    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
+    // Labels can be added as regular properties.
     LabelUpdate labels = 4;
 
     // Comments are the human-readable extended descriptions (language-specific) to add or remove.
+    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
+    // Comments can be added as regular properties.
     CommentUpdate comments = 5;
 
     // Location to be set/unset
@@ -319,6 +337,7 @@ message UpdateTwinResponse {
 }
 
 // UpsertTwinRequest describes the full state of a twin + its feeds to create or update (full update)
+// Deprecation: twin/feed labels and comments are now ignored and will be removed as part of the next major release.
 message UpsertTwinRequest {
 
   // UpsertTwinRequest payload. This state will be applied to the twin/feeds
@@ -331,9 +350,13 @@ message UpsertTwinRequest {
     Visibility visibility = 2;
 
     // Labels are human-readable set of labels (language-specific) to set
+    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
+    // Labels can be added as regular properties.
     repeated LangLiteral labels = 3;
 
     // Comments are human-readable set of labels (language-specific) to set
+    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
+    // Labels can be added as regular properties.
     repeated LangLiteral comments = 4;
 
     // Twin Properties to set
@@ -352,6 +375,7 @@ message UpsertTwinRequest {
   // UpdateTwinRequest payload
   Payload payload = 2;
 }
+
 // UpsertTwinResponse is received when a twin and its feeds have been created/updated.
 message UpsertTwinResponse {
 


### PR DESCRIPTION
New:
- Update feed request: properties field
- Upsert twin request: feed properties field
- Describe feed response: feed properties field
- Search response (FULL type):  feed properties field

Deprecations:
- Update twin: labels, comments and tags fields are not ignored
- Upsert twin: labels and comments fields are not ignored
- Update feed: labels, comments and tags fields are not ignored
- Describe twin: ignores lang filtering
- Describe twin: no longer returns tags/labels/comments (empty fields)
- Describe feed: ignores lang filtering
- Describe feed: no longer returns tags/labels/comments (empty fields)
