### PR TITLE
EI-587 - New structure: generic properties first - Breaking change

### DIFF
--- a/proto/iotics/api/common.proto
+++ b/proto/iotics/api/common.proto
@@ -110,26 +110,6 @@ message GeoCircle {
   double radiusKm = 2;
 }
 
-// LabelUpdate describes labels metadata property update: addition and deletion of labels with language.
-// DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-message LabelUpdate {
-  // List of labels to be added. (Note: Only one label per language is stored, i.e. any existing ones with the same
-  // language will be replaced.)
-  repeated LangLiteral added = 1;
-  // List of languages for which to remove labels
-  repeated string deletedByLang = 2;
-}
-
-// CommentUpdate describes comments metadata property update: addition and deletion of comments with language.
-// DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-message CommentUpdate {
-  // List of labels to be added. (Note: Only one comment per language is stored, i.e. any existing ones with the same
-  // language will be replaced.)
-  repeated LangLiteral added = 1;
-  // List of languages for which to remove comments
-  repeated string deletedByLang = 2;
-}
-
 // Visibility defines who a twin is visible to.
 // PRIVATE - the twin is only visible in a LOCAL scope.
 // PUBLIC - the twin is visible in any scope.
@@ -144,16 +124,6 @@ enum Visibility {
 enum Scope {
   GLOBAL = 0;
   LOCAL = 1;
-}
-
-// Tags describes tags metadata property update: list of tags to be added and deleted. if a tag appears in both lists,
-// applications may choose to ignore the tags or throw some error.
-// DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-message Tags {
-  // List of tags to be added
-  repeated string added = 1;
-  // List of tags to be deleted
-  repeated string deleted = 2;
 }
 
 // Headers describes the common headers applicable to all the API requests
@@ -250,4 +220,22 @@ message FeedData {
   // data is the actual set of datapoints, encoded according the the mime type. The data should follow the Feed's
   // value defintions but that is not enforced. (See also Value)
   bytes data = 4;
+}
+
+
+// PropertyUpdate describes the update of a twin properties.
+// Can be used to add, replace, or delete properties. The order of operations is:
+// clearedAll (if True), deleted, deletedByKey, added.
+// Note that internal properties (such as location) cannot be modified here.
+message PropertyUpdate {
+
+  // Delete all properties currently set on the twin.
+  bool clearedAll = 1;
+
+  // Delete specific exact properties (by key and value). This operation is ignored if clearAll is True.
+  repeated Property deleted = 2;
+  // Delete any properties with the given keys (predicates). This operation is ignored if clearAll is True.
+  repeated string deletedByKey = 3;
+  // Adds the given properties
+  repeated Property added = 4;
 }

--- a/proto/iotics/api/feed.proto
+++ b/proto/iotics/api/feed.proto
@@ -24,15 +24,12 @@ option php_namespace = "Iotics\\Api";
 // A feed generates data in a 1-to-many relationship: one feed may produce data that is used by many consumers (twins).
 service FeedAPI {
   // Creates a feed owned by a twin. (Idempotent)
-  // Deprecation: CreateFeedRequest.payload.storeLast is no longer used. Please use UpdateFeed or UpsertTwin to set feed storeLast value.
-  // Deprecation: CreateFeedResponse.payload.alreadyCreated is no longer set (the service remains idempotent).
   rpc CreateFeed(CreateFeedRequest) returns (CreateFeedResponse) {}
 
   // Deletes a feed owned by a twin. (Idempotent)
   rpc DeleteFeed(DeleteFeedRequest) returns (DeleteFeedResponse) {}
 
   // Updates attributes of a feed, including its metadata.
-  // Deprecation: tags, labels and comments are now ignored and will be removed as part of the next major release.
   rpc UpdateFeed(UpdateFeedRequest) returns (UpdateFeedResponse) {}
 
   // Shares a new sample of data for the given feed which any (interest) subscribers can receive.
@@ -42,8 +39,6 @@ service FeedAPI {
   rpc ListAllFeeds(ListAllFeedsRequest) returns (ListAllFeedsResponse) {}
 
   // Describe feed.
-  // Deprecation: lang filter request field is now ignored.
-  // Deprecation: tags, labels and comments response fields are no longer returned.
   rpc DescribeFeed(DescribeFeedRequest) returns (DescribeFeedResponse) {}
 }
 
@@ -56,15 +51,12 @@ message Feed {
 }
 
 // CreateFeedRequestCreate is used to create a new feed in a given twin.
-// Deprecation: CreateFeedRequest.payload.storeLast is no longer used. Please use UpdateFeed or UpsertTwin to set feed storeLast value.
 message CreateFeedRequest {
   // Payload describes the data needed to create a feed.
   message Payload {
     // ID of the feed to create
     FeedID feedId = 1;
     // StoreLast indicates if the last received value should be stored of not
-    // Deprecated: storeLast can be set using UpdateFeedRequest or UpsertFeedWithMeta
-    bool storeLast = 2;
   }
   // Arguments describes the mandatory arguments to identify the twin the feed belongs to.
   message Arguments {
@@ -81,15 +73,12 @@ message CreateFeedRequest {
 }
 
 // CreateFeedResponse describes a created feed.
-// Deprecation: CreateFeedResponse.payload.alreadyCreated is no longer set (the service remains idempotent).
 message CreateFeedResponse {
   // CreateFeedResponse payload.
   message Payload {
     // The created feed
     Feed feed = 1;
     // AlreadyCreated indicates if the feed already existed (the create is idempotent)
-    // Deprecated: no longer set
-    bool alreadyCreated = 2;
   }
   // CreateFeedResponse headers
   Headers headers = 1;
@@ -128,26 +117,7 @@ message DeleteFeedResponse {
 // ---------------------------------------
 
 // UpdateFeedRequest is used to update attributes (including metadata) of a given feed.
-// Deprecation: tags, labels and comments are now ignored and will be removed as part of the next major release.
 message UpdateFeedRequest {
-  // Soft breaking change: move to common once ready for real breaking change
-
-  // PropertyUpdate describes the update of feed properties.
-  // Can be used to add, replace, or delete properties. The order of operations is:
-  // clearedAll (if True), deleted, deletedByKey, added.
-  // Note that internal properties (such as location) cannot be modified here.
-  message PropertyUpdate {
-
-    // Delete all properties currently set on the twin.
-    bool clearedAll = 1;
-
-    // Delete specific exact properties (by key and value). This operation is ignored if clearAll is True.
-    repeated Property deleted = 2;
-    // Delete any properties with the given keys (predicates). This operation is ignored if clearAll is True.
-    repeated string deletedByKey = 3;
-    // Adds the given properties
-    repeated Property added = 4;
-  }
 
   // UpdateFeedRequest payload. One or more fields can be provided, depending on what needs to be updated.
   // Note that the specified metadata changes are applied in the following order:
@@ -156,19 +126,8 @@ message UpdateFeedRequest {
 
     // storeLast dictates whether to store the last shared sample of a feed.
     google.protobuf.BoolValue storeLast = 1;
-    // tags are the set of tags to add or remove.
-    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-    Tags tags = 2;
     // values are descriptive individual data items to add/remove.
     Values values = 3;
-    // labels are human-readable set of labels (language-specific) to add or remove.
-    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-    // Labels can be added as regular properties.
-    LabelUpdate labels = 4;
-    // comments are the human-readable extended descriptions (language-specific) to add or remove.
-    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-    // Comment can be added as regular properties.
-    CommentUpdate comments = 5;
     // Custom properties to add/remove. Internal properties (such as location) cannot be modified here.
     PropertyUpdate properties = 6;
   }
@@ -261,7 +220,6 @@ message ListAllFeedsResponse {
 }
 
 // Description of twin: Provides public metadata lookup for individual resources.
-// Deprecation: lang filter request field is now ignored.
 message DescribeFeedRequest {
 
   // Only one action argument is necessary.
@@ -273,35 +231,19 @@ message DescribeFeedRequest {
     HostID remoteHostId = 2;
   }
   Headers headers = 1;
-  // Language code for labels and comments. If set, only the label and comment in the given language will be returned
-  // instead of all. This field does not apply to values and tags which are always returned in full.
-  // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-  google.protobuf.StringValue lang = 2;
   // DescribeFeedRequest mandatory arguments
   Arguments args = 3;
 }
 // Describe feed response.
-// Deprecation: tags, labels and comments response fields are no longer returned.
 message DescribeFeedResponse {
   Headers headers = 1;
 
 
   // Metadata result databag.
   message MetaResult {
-    // Labels in all languages set for the feed. (Or: Only label in chosen language, if lang field was specified in the
-    // request.)
-    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-    // Labels are no longer special properties.
-    repeated LangLiteral labels = 1;
     // values semantically describing the share payload of Feed or expected arguments for a Control request
     repeated Value values = 2;
-    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-    repeated string tags = 3;
-    // Comments in all languages set for the feed. (Or: Only comment in chosen language, if lang field was specified in
-    // the request.)
-    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-    // Comments are no longer special properties
-    repeated LangLiteral comments = 4;
+
     // Whether this feed might have its most recent data sample stored. If so, it can be retrieved via FetchLastStored
     // request. (See interest API)
     bool storeLast = 5;
@@ -323,16 +265,6 @@ message DescribeFeedResponse {
 message UpsertFeedWithMeta {
   // Id of the feed to create/update
   string id = 1;
-
-  // Labels are human-readable set of labels (language-specific) to set
-  // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-  // Labels can be added as regular properties.
-  repeated LangLiteral labels = 2;
-
-  // Comments are human-readable set of labels (language-specific) to set
-  // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-  // Comments can be added as regular properties.
-  repeated LangLiteral comments = 3;
 
   // storeLast dictates whether to store the last shared sample of the feed. Default 'False'
   bool storeLast = 4;

--- a/proto/iotics/api/search.proto
+++ b/proto/iotics/api/search.proto
@@ -24,16 +24,12 @@ option php_namespace = "Iotics\\Api";
 // SearchAPI provides a set of services to run synchronous and asynchronous search.
 service SearchAPI {
   // Send a search request. Results are expected asynchronously.
-  // Deprecation: search by text is now applied to twin rdfs:comment/rdfs:label instead of iotics:label/iotics:comments.
   rpc DispatchSearchRequest(SearchRequest) returns (DispatchSearchResponse) {}
 
   // Run a synchronous search based on a user timeout.
-  // Deprecation: search by text is now applied to twin rdfs:comment/rdfs:label instead of iotics:label/iotics:comments.
-  // Deprecation: tags and labels response fields are no longer returned.
   rpc SynchronousSearch(SearchRequest) returns (stream SearchResponse) {}
 
   // Receive all search responses associated to a set of Search request for a given client application ID.
-  // Deprecation: tags and labels response fields are no longer returned.
   rpc ReceiveAllSearchResponses(SubscriptionHeaders) returns (stream SearchResponse) {}
 }
 
@@ -48,7 +44,6 @@ enum ResponseType {
 }
 
 // SearchRequest describes a search request used for both synchronous and asynchronous search.
-// Deprecation: search by text is now applied to twin rdfs:comment/rdfs:label instead of iotics:label/iotics:comments.
 message SearchRequest {
   // Search request payload.
   message Payload {
@@ -92,15 +87,11 @@ message SearchRequest {
 // It contains all the matching twins/feeds according to the request scope/range/lang/filters in the expected response type format.
 // In the decentralised iotics operating environment, each node in the network generates a response and the client is expected to
 // receive a stream of response messages.
-// Deprecation: tags and labels response fields are no longer returned.
 message SearchResponse {
   // Search response feed details. Included with response type: FULL.
   message FeedDetails {
     // Feed
     Feed feed = 1;
-    // The feed human readable label in the language specified in the request (if set)
-    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-    string label = 2;
     // whether offers the ability to store last received value
     bool storeLast = 3;
     // Feed custom properties.
@@ -114,12 +105,6 @@ message SearchResponse {
     TwinID id = 1;
     // Twin location (if set). Included with response type: FULL and LOCATED
     GeoLocation location = 2;
-    // Twin human readable label in the language specified in the request (if set). Included with response type: FULL and LOCATED
-    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-    string label = 3;
-    // Twin tags. Included with response type: FULL
-    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-    repeated string tags = 4;
     // Twin custom properties.
     repeated Property properties = 5;
     // Feed details. Included with response type: FULL

--- a/proto/iotics/api/twin.proto
+++ b/proto/iotics/api/twin.proto
@@ -24,31 +24,20 @@ option php_namespace = "Iotics\\Api";
 service TwinAPI {
 
   // CreateTwin creates a twin.
-  // Deprecation: CreateTwinResponse.payload.twin.visibility is no longer set.
-  // The twin visibility can be obtained through a call to DescribeTwin.
-  // Deprecation: CreateTwinResponse.payload.alreadyCreated is no longer set (the service remains idempotent).
   rpc CreateTwin(CreateTwinRequest) returns (CreateTwinResponse) {}
 
   // UpsertTwin creates or update a twin with its metadata + the twin feeds with their metadata.
   // The full state is applied (ie. if the operation succeeds the state of the twin/feeds will be the one
   // described in the payload)
-  // Deprecation: twin/feed labels and comments are now ignored and will be removed as part of the next major release.
   rpc UpsertTwin(UpsertTwinRequest) returns (UpsertTwinResponse) {}
 
   // DeleteTwin deletes a twin.
-  // Deprecation: DeleteTwinResponse.payload.twin.visibility is no longer set.
-  // The twin visibility can be obtained through a call to DescribeTwin.
   rpc DeleteTwin(DeleteTwinRequest) returns (DeleteTwinResponse) {}
 
   // UpdateTwin updates a twin (partial update).
-  // Deprecation: UpdateTwinResponse.payload.twin.visibility is no longer set.
-  // The twin visibility can be obtained through a call to DescribeTwin.
-  // Deprecation: tags, labels and comments are now ignored and will be removed as part of the next major release.
   rpc UpdateTwin(UpdateTwinRequest) returns (UpdateTwinResponse) {}
 
   // Describes a twin.
-  // Deprecation: lang filter request field is now ignored.
-  // Deprecation: tags, labels and comments response fields are no longer returned.
   rpc DescribeTwin(DescribeTwinRequest) returns (DescribeTwinResponse) {}
 
   // List all twins.
@@ -63,7 +52,6 @@ message Twin {
   TwinID id = 1;
 
   // Visibility of this twin
-  // Deprecated: the field is no longer set except for DescribeTwinResponse and ListAllTwinsResponse
   Visibility visibility = 2;
 }
 
@@ -87,19 +75,6 @@ message ListAllTwinsResponse {
   Payload payload = 2;
 }
 
-// Message returned by the List service as a stream.
-message ListTwinsResponse {
-  Headers headers = 1;
-
-  // Payload of listed twins.
-  message Payload {
-    // the twin - may be omitted if the response code is not a success code
-    Twin twin = 1;
-  }
-  Payload payload = 2;
-}
-
-
 // CreateTwinRequest is made to create a twin (idempotent).
 message CreateTwinRequest {
   // Arguments identifies the twin to create.
@@ -116,19 +91,12 @@ message CreateTwinRequest {
 }
 
 // CreateTwinResponse is received when a twin has been created.
-// Deprecation: resp.payload.twin.visibility is no longer set.
-// The twin visibility can be obtained through a call to DescribeTwin.
-// Deprecation: resp.payload.alreadyCreated is no longer set (the service remains idempotent).
 message CreateTwinResponse {
 
   // Payload identifies the twin which was created.
   message Payload {
-    // created twin
-    Twin twin = 1;
-
-    // whether the twin exists already (creating an existing twin is idempotent). Optional, with default=false.
-    // Deprecated: no longer set
-    bool alreadyCreated = 2;
+    // Unique ID of the twin to delete
+    TwinID twinId = 1;
   }
 
   // Common headers
@@ -157,14 +125,12 @@ message DeleteTwinRequest {
 }
 
 // Deleted is received when a twin has been deleted.
-// Deprecation: resp.payload.twin.visibility is no longer set.
-// The twin visibility can be obtained through a call to DescribeTwin.
 message DeleteTwinResponse {
 
   // Payload identifies the twin which was deleted.
   message Payload {
-    // Details of twin which was deleted
-    Twin twin = 1;
+    // Unique ID of the twin to delete
+    TwinID twinId = 1;
   }
 
   // Common headers
@@ -175,7 +141,6 @@ message DeleteTwinResponse {
 }
 
 // Description of twin: Provides public metadata lookup for individual resources.
-// Deprecation: lang filter request field is now ignored.
 message DescribeTwinRequest {
   // Only one action argument is necessary.
   message Arguments {
@@ -188,23 +153,16 @@ message DescribeTwinRequest {
 
   Headers headers = 1;
 
-  // Language code for labels and comments. If set, only the label and comment in the given language will be returned
-  // instead of all. This field does not apply to tags and properties which are always returned in full.
-  // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-  google.protobuf.StringValue lang = 2;
-
   Arguments args = 3;
 }
 
 // Metadata message for this Feed.
 message FeedMeta {
   FeedID feedId = 1;
-  repeated LangLiteral labels = 2;
   bool storeLast = 3;
 }
 
 // The response for a description request on this twin.
-// Deprecation: tags, labels and comments response fields are no longer returned.
 message DescribeTwinResponse {
   Headers headers = 1;
 
@@ -212,19 +170,7 @@ message DescribeTwinResponse {
   // Metadata result data bag for this feed.
   message MetaResult {
     GeoLocation location = 1;
-    // Labels in all languages set for the twin. (Or: Only label in chosen language, if lang field was specified in
-    // the request.)
-    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-    // Labels are no longer special properties.
-    repeated LangLiteral labels = 2;
-    // Comments in all languages set for the twin. (Or: Only comment in chosen language, if lang field was specified
-    // in the request.)
-    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-    // Comments are no longer special properties
-    repeated LangLiteral comments = 3;
     repeated FeedMeta feeds = 4;
-    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-    repeated string tags = 5;
     // Custom properties associated with this twin.
     repeated Property properties = 6;
   }
@@ -246,23 +192,6 @@ message DescribeTwinResponse {
 
 // ---------------------------------------
 
-// PropertyUpdate describes the update of a twin properties.
-// Can be used to add, replace, or delete properties. The order of operations is:
-// clearedAll (if True), deleted, deletedByKey, added.
-// Note that internal properties (such as location) cannot be modified here.
-message PropertyUpdate {
-
-  // Delete all properties currently set on the twin.
-  bool clearedAll = 1;
-
-  // Delete specific exact properties (by key and value). This operation is ignored if clearAll is True.
-  repeated Property deleted = 2;
-  // Delete any properties with the given keys (predicates). This operation is ignored if clearAll is True.
-  repeated string deletedByKey = 3;
-  // Adds the given properties
-  repeated Property added = 4;
-}
-
 // VisibilityUpdate describes the update of a twin visibility.
 message VisibilityUpdate {
   // New visibility for this twin
@@ -276,7 +205,6 @@ message GeoLocationUpdate {
 }
 
 // UpdateTwinRequest is used to update attributes (including metadata) of a given twin.
-// Deprecation: tags, labels and comments are now ignored and will be removed as part of the next major release.
 message UpdateTwinRequest {
   // UpdateTwinRequest mandatory arguments.
   message Arguments {
@@ -287,25 +215,11 @@ message UpdateTwinRequest {
   // Note that the specified metadata changes are applied in the following order:
   // tags, visibility, properties, labels, comments, location
   message Payload {
-    // Tags are the set of tags to add or remove.
-    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-    Tags tags = 1;
-
     // New visibility
     VisibilityUpdate newVisibility = 2;
 
     // Custom properties to add/remove. Internal properties (such as location) cannot be modified here.
     PropertyUpdate properties = 3;
-
-    // Labels are human-readable set of labels (language-specific) to add or remove.
-    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-    // Labels can be added as regular properties.
-    LabelUpdate labels = 4;
-
-    // Comments are the human-readable extended descriptions (language-specific) to add or remove.
-    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-    // Comments can be added as regular properties.
-    CommentUpdate comments = 5;
 
     // Location to be set/unset
     GeoLocationUpdate location = 6;
@@ -322,13 +236,11 @@ message UpdateTwinRequest {
 
 
 // UpdateTwinResponse describes an updated twin. It is received when the update operation is successful.
-// Deprecation: resp.payload.twin.visibility is no longer set.
-// The twin visibility can be obtained through a call to DescribeTwin.
 message UpdateTwinResponse {
   // UpdateTwinResponse payload.
   message Payload {
-    // Updated Twin
-    Twin twin = 1;
+    // Unique ID of the twin to delete
+    TwinID twinId = 1;
   }
   // UpdateTwinResponse headers
   Headers headers = 1;
@@ -337,7 +249,6 @@ message UpdateTwinResponse {
 }
 
 // UpsertTwinRequest describes the full state of a twin + its feeds to create or update (full update)
-// Deprecation: twin/feed labels and comments are now ignored and will be removed as part of the next major release.
 message UpsertTwinRequest {
 
   // UpsertTwinRequest payload. This state will be applied to the twin/feeds
@@ -348,16 +259,6 @@ message UpsertTwinRequest {
 
     // Twin visibility. Default value: 'PRIVATE'
     Visibility visibility = 2;
-
-    // Labels are human-readable set of labels (language-specific) to set
-    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-    // Labels can be added as regular properties.
-    repeated LangLiteral labels = 3;
-
-    // Comments are human-readable set of labels (language-specific) to set
-    // DEPRECATED: will be removed in the next major release. Not read/set anymore, will be considered as a no-op.
-    // Labels can be added as regular properties.
-    repeated LangLiteral comments = 4;
 
     // Twin Properties to set
     repeated Property properties = 5;


### PR DESCRIPTION
Original PR (now superseded):
- https://github.com/Iotic-Labs/api/pull/4

---

New:

    * Update feed request: properties field
    * Upsert twin request: feed properties field
    * Describe feed response: feed properties field
    * Search response (FULL type): feed properties field
    
Breaking change:
    
    * Update twin: labels, comments and tags fields are removed
    * Upsert twin: labels and comments fields are removed
    * Update feed: labels, comments and tags fields are removed
    * Describe twin: lang filtering is removed
    * Describe twin: tags/labels/comments fielda are removed
    * Describe feed: lang filtering is removed
    * Describe feed: tags/labels/comments fielda are removed
    * Create feed: storeLast is removed from request / alreadyCreated is removed from response
    * Create/Delete/Update twin: response only include twin ID
    * PropertyUpdate Object is now in common

** NO MERGE ** before syncup meeting