### PR TITLE
EI-1103 - Add new Input API

### DIFF
--- a/proto/iotics/api/common.proto
+++ b/proto/iotics/api/common.proto
@@ -86,12 +86,6 @@ message Property {
   }
 }
 
-// PointType used to describe a point as a FEED or a CONTROL.
-enum PointType {
-  FEED = 0;
-  CONTROL = 1;
-}
-
 // GeoLocation is the geographic location of a Twin.
 message GeoLocation {
   // Latitude
@@ -211,11 +205,12 @@ message Values {
 message FeedData {
   // occurredAt is the UTC timestamp of the sample. Typically this is either the time at which an application shared
   // this sample or the time applicable to the sample itself (such as an hourly weather observation).
+  // (Optional: set to host time is not provided)
   google.protobuf.Timestamp occurredAt = 2;
   // mime is the mime type of the encoded data.
   string mime = 3;
   // data is the actual set of datapoints, encoded according the the mime type. The data should follow the Feed's
-  // value defintions but that is not enforced. (See also Value)
+  // value definitions but that is not enforced. (See also Value)
   bytes data = 4;
 }
 

--- a/proto/iotics/api/common.proto
+++ b/proto/iotics/api/common.proto
@@ -169,9 +169,15 @@ message TwinID {
   string value = 1;
 }
 
-// FeedID is a unique feed identifier (scoped to the TwinID).
+// FeedID is a unique feed identifier (scoped to the set of feed for a TwinID).
 message FeedID {
   // Feed Identifier string representation (simple string)
+  string value = 1;
+}
+
+// InputID is a unique input identifier (scoped to the set of input for a TwinID).
+message InputID {
+  // Input Identifier string representation (simple string)
   string value = 1;
 }
 

--- a/proto/iotics/api/feed.proto
+++ b/proto/iotics/api/feed.proto
@@ -23,30 +23,30 @@ option php_namespace = "Iotics\\Api";
 // A twin may have one or more feeds. Any twin can subscribe to a feed (access control permitting).
 // A feed generates data in a 1-to-many relationship: one feed may produce data that is used by many consumers (twins).
 service FeedAPI {
-  // Creates a feed owned by a twin. (Idempotent)
+  // Creates a feed owned by a twin. (Idempotent - local only)
   rpc CreateFeed(CreateFeedRequest) returns (CreateFeedResponse) {}
 
-  // Deletes a feed owned by a twin. (Idempotent)
+  // Deletes a feed owned by a twin. (Idempotent - local only)
   rpc DeleteFeed(DeleteFeedRequest) returns (DeleteFeedResponse) {}
 
-  // Updates attributes of a feed, including its metadata.
+  // Updates attributes of a feed, including its metadata. (local only)
   rpc UpdateFeed(UpdateFeedRequest) returns (UpdateFeedResponse) {}
 
-  // Shares a new sample of data for the given feed which any (interest) subscribers can receive.
+  // Shares a new sample of data for the given feed which any (interest) subscribers can receive. (local only)
   rpc ShareFeedData(ShareFeedDataRequest) returns (ShareFeedDataResponse) {}
 
-  // List all feeds owned by a twin.
+  // List all feeds owned by a twin. (local only)
   rpc ListAllFeeds(ListAllFeedsRequest) returns (ListAllFeedsResponse) {}
 
-  // Describe feed.
+  // Describe feed. (local and remote)
   rpc DescribeFeed(DescribeFeedRequest) returns (DescribeFeedResponse) {}
 }
 
 // A feed representation.
 message Feed {
-  // feed identifier (unique within the scope of a twin identifier)
+  // Feed identifier (unique within the scope of a twin identifier feed set)
   FeedID id = 1;
-  // twin unique identifier (twin to which the feed belongs)
+  // Twin unique identifier (twin to which the feed belongs)
   TwinID twinId = 2;
 }
 
@@ -78,14 +78,13 @@ message CreateFeedResponse {
   message Payload {
     // The created feed
     Feed feed = 1;
-    // AlreadyCreated indicates if the feed already existed (the create is idempotent)
   }
+
   // CreateFeedResponse headers
   Headers headers = 1;
   // CreateFeedResponse payload
   Payload payload = 2;
 }
-
 // ---------------------------------------
 
 // DeleteFeedRequest is used to delete a feed from a given twin.
@@ -95,43 +94,41 @@ message DeleteFeedRequest {
     // Feed to delete
     Feed feed = 1;
   }
+
   // DeleteFeedRequest headers
   Headers headers = 1;
   // DeleteFeedRequest mandatory arguments
   Arguments args = 2;
 }
 
-
 // DeleteFeedResponse describes a deleted feed.
 message DeleteFeedResponse {
   // DeleteFeedResponse payload.
   message Payload {
+    // Deleted feed
     Feed feed = 1;
   }
+
   // DeleteFeedResponse headers
   Headers headers = 1;
   // DeleteFeedResponse payload
   Payload payload = 2;
 }
-
 // ---------------------------------------
 
 // UpdateFeedRequest is used to update attributes (including metadata) of a given feed.
 message UpdateFeedRequest {
-
   // UpdateFeedRequest payload. One or more fields can be provided, depending on what needs to be updated.
   // Note that the specified metadata changes are applied in the following order:
   // tags, values, labels, comments
   message Payload {
-
-    // storeLast dictates whether to store the last shared sample of a feed.
+    // StoreLast dictates whether to store the last shared sample of a feed.
     google.protobuf.BoolValue storeLast = 1;
-    // values are descriptive individual data items to add/remove.
+    // Values are descriptive individual data items to add/remove.
     Values values = 3;
     // Custom properties to add/remove. Internal properties (such as location) cannot be modified here.
     PropertyUpdate properties = 6;
   }
-
   // UpdateFeedRequest arguments.
   message Arguments {
     Feed feed = 1;
@@ -149,26 +146,27 @@ message UpdateFeedRequest {
 message UpdateFeedResponse {
   // UpdateFeedResponse payload.
   message Payload {
-    // Updated Twin
+    // Updated feed
     Feed feed = 1;
   }
+
   // UpdateFeedResponse headers
   Headers headers = 1;
   //UpdateFeedResponse payload
   Payload payload = 2;
 }
-
 // ---------------------------------------
 
 // ShareFeedDataRequest is used to share a new sample of data for the given feed.
 message ShareFeedDataRequest {
-
   // ShareFeedDataRequest payload.
   message Payload {
+    // Sample to share
     FeedData sample = 1;
   }
   // ShareFeedDataRequest arguments.
   message Arguments {
+    // Feed sharing the sample
     Feed feed = 1;
   }
 
@@ -186,7 +184,6 @@ message ShareFeedDataResponse {
   // ShareFeedDataResponse headers
   Headers headers = 1;
 }
-
 // ---------------------------------------
 
 // ListAllFeedsRequest is used to list all the feeds owned by a given twin.
@@ -196,6 +193,7 @@ message ListAllFeedsRequest {
     // Identifier of the twin owning this feed
     TwinID twinId = 1;
   }
+
   // ListAllFeedsRequest headers
   Headers headers = 1;
   // ListAllFeedsRequest arguments
@@ -211,39 +209,37 @@ message ListAllFeedsResponse {
   message Payload {
     // List of the feeds owned by the twin
     repeated Feed feeds = 1;
-
   }
+
   // ListAllFeedsResponse headers
   Headers headers = 1;
   // ListAllFeedsResponse payload
   Payload payload = 2;
 }
+// ---------------------------------------
 
 // Description of twin: Provides public metadata lookup for individual resources.
 message DescribeFeedRequest {
-
-  // Only one action argument is necessary.
+  // DescribeFeedRequest arguments.
   message Arguments {
     // Feed to describe
     Feed feed = 1;
-
-    // optional HostID to describe a remote feed
+    // HostID to describe a remote input (Optional, keep empty if feed is local)
     HostID remoteHostId = 2;
   }
+
+  // DescribeFeedRequest headers
   Headers headers = 1;
   // DescribeFeedRequest mandatory arguments
   Arguments args = 3;
 }
+
 // Describe feed response.
 message DescribeFeedResponse {
-  Headers headers = 1;
-
-
   // Metadata result databag.
   message MetaResult {
-    // values semantically describing the share payload of Feed or expected arguments for a Control request
+    // Values semantically describing the share payload of Feed
     repeated Value values = 2;
-
     // Whether this feed might have its most recent data sample stored. If so, it can be retrieved via FetchLastStored
     // request. (See interest API)
     bool storeLast = 5;
@@ -251,27 +247,31 @@ message DescribeFeedResponse {
     // Custom properties associated with this feed.
     repeated Property properties = 6;
   }
-
   // DescribeFeedResponse payload.
   message Payload {
+    // Described feed
     Feed feed = 1;
+    // Metadata result
     MetaResult result = 2;
+    // HostID of the described feed. (Optional, empty if input is local)
     HostID remoteHostId = 3;
   }
+
+  // DescribeFeedResponse headers
+  Headers headers = 1;
+  // DescribeFeedResponse payload
   Payload payload = 2;
 }
+// ---------------------------------------
 
 // UpsertFeedWithMeta is used to describe the full feed state. Used in UpsertTwinRequest.
 message UpsertFeedWithMeta {
   // Id of the feed to create/update
   string id = 1;
-
-  // storeLast dictates whether to store the last shared sample of the feed. Default 'False'
+  // StoreLast dictates whether to store the last shared sample of the feed. Default 'False'
   bool storeLast = 4;
-
-  // values to set
+  // Values to set
   repeated Value values = 5;
-
-  // feed properties to set
+  // Feed properties to set
   repeated Property properties = 6;
 }

--- a/proto/iotics/api/input.proto
+++ b/proto/iotics/api/input.proto
@@ -1,0 +1,199 @@
+// Copyright (c) 2019-2022 Iotic Labs Ltd. All rights reserved.
+
+// Iotics Web protocol definitions (feed)
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+import "iotics/api/common.proto";
+
+package iotics.api;
+
+option csharp_namespace = "Iotics.Api";
+option go_package = "github.com/Iotic-Labs/iotic-go-proto-qapi/iotics/api;ioticsapi";
+option java_multiple_files = true;
+option java_outer_classname = "InputProto";
+option java_package = "com.iotics.api";
+option objc_class_prefix = "IAX";
+option php_namespace = "Iotics\\Api";
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+// Input API groups all the actions link to a twin input
+service InputAPI {
+
+  // Deletes an input. (Idempotent - local only)
+  rpc DeleteInput(DeleteInputRequest) returns (DeleteInputResponse) {}
+
+  // Describe an input (local or remote)
+  rpc DescribeInput(DescribeInputRequest) returns (DescribeInputResponse) {}
+
+  // Send a message to an input (local or remote)
+  rpc SendInputMessage(SendInputMessageRequest) returns (SendInputMessageResponse) {}
+
+  // Receive input messages (local only)
+  rpc ReceiveInputMessages(ReceiveInputMessageRequest) returns (stream ReceiveInputMessageResponse) {}
+}
+
+// Representation of an input.
+message Input {
+  // Input identifier (unique within the scope of a twin identifier input set)
+  InputID id = 1;
+  // Twin unique identifier (twin to which the input belongs)
+  TwinID twinId = 2;
+}
+// ---------------------------------------
+
+// DeleteInputRequest is used to delete an input from a given twin.
+message DeleteInputRequest {
+  // DeleteInputRequest arguments.
+  message Arguments {
+    // Input to delete
+    Input input = 1;
+  }
+
+  // DeleteInputRequest headers
+  Headers headers = 1;
+  // DeleteInputRequest mandatory arguments
+  Arguments args = 2;
+}
+
+// DeleteInputResponse describes a deleted input.
+message DeleteInputResponse {
+  // DeleteInputResponse payload.
+  message Payload {
+    // Deleted input
+    Input input = 1;
+  }
+
+  // DeleteInputResponse headers
+  Headers headers = 1;
+  // DeleteInputResponse payload
+  Payload payload = 2;
+}
+// ---------------------------------------
+
+// DescribeInputRequest is used to request the input metadata.
+message DescribeInputRequest {
+  // DescribeInputRequest arguments.
+  message Arguments {
+    // Input to describe
+    Input input = 1;
+    // HostID to describe a remote input (Optional, keep empty if input is local)
+    HostID remoteHostId = 2;
+  }
+
+  // DescribeInputRequest headers
+  Headers headers = 1;
+  // DescribeInputRequest mandatory arguments
+  Arguments args = 2;
+}
+
+// DescribeInputResponse provides metadata lookup for individual input resources.
+message DescribeInputResponse {
+  // DescribeInputResponse metadata result.
+  message MetaResult {
+    // Values semantically describing the Input messages
+    repeated Value values = 1;
+    // Custom properties associated with this input.
+    repeated Property properties = 2;
+  }
+  // DescribeInputResponse payload.
+  message Payload {
+    // Described input
+    Input input = 1;
+    // Metadata result
+    MetaResult result = 2;
+    // HostID of the described input. (Optional, empty if input is local)
+    HostID remoteHostId = 3;
+  }
+
+  // DescribeInputResponse headers
+  Headers headers = 1;
+  // DescribeInputResponse payload
+  Payload payload = 2;
+}
+// ---------------------------------------
+
+// UpsertInputWithMeta is used to describe the full input state. Used in UpsertTwinRequest.
+message UpsertInputWithMeta {
+  // Id of the input to create/update
+  string id = 1;
+  // Values to set
+  repeated Value values = 2;
+  // Properties to set
+  repeated Property properties = 3;
+}
+// ---------------------------------------
+
+// InputMessage describe a message that can be sent to an input
+message InputMessage {
+  // OccurredAt is the UTC timestamp of the message.
+  // Typically this is either the time at which an application sent this message
+  // or the time applicable to the message itself. (Optional: set to host time is not provided)
+  google.protobuf.Timestamp occurredAt = 1;
+  // Mime is the mime type of the encoded data.
+  string mime = 2;
+  // Data is the actual message, encoded according the the mime type. The data should follow the Input's
+  // value definitions but that is not enforced. (See also Value)
+  bytes data = 3;
+}
+// ---------------------------------------
+
+// ReceiveInputMessageRequest is used to receive messages sent to a given Input.
+message ReceiveInputMessageRequest {
+  // ReceiveInputMessageRequest arguments.
+  message Arguments {
+    // Input to listen messages from
+    Input input = 1;
+  }
+
+  // ReceiveInputMessageRequest headers
+  Headers headers = 1;
+  // ReceiveInputMessageRequest mandatory arguments
+  Arguments args = 2;
+}
+
+// ReceiveInputMessageResponse contains a message sent to the Input.
+message ReceiveInputMessageResponse {
+  message Payload {
+    // Input the message has been sent to
+    Input input = 1;
+    // Input message
+    InputMessage message = 2;
+  }
+
+  // ReceiveInputMessageResponse headers
+  Headers headers = 1;
+  // ReceiveInputMessageResponse payload
+  Payload payload = 2;
+}
+// ---------------------------------------
+
+// SendInputMessageRequest is used to send a message to a given input
+message SendInputMessageRequest {
+  // SendInputMessageRequest payload.
+  message Payload {
+    // Message to send
+    InputMessage message = 1;
+  }
+  // SendInputMessageRequest arguments
+  message Arguments {
+    // Input to send the message to
+    Input input = 1;
+    // HostID to identify a remote input (Optional, keep empty if input is local)
+    HostID hostId = 2;
+  }
+
+  // SendInputMessageRequest headers
+  Headers headers = 1;
+  // SendInputMessageRequest mandatory arguments
+  Arguments args = 2;
+  // SendInputMessageRequest payload
+  Payload payload = 3;
+}
+
+// SendInputMessageResponse is used to indicate a successful send.
+message SendInputMessageResponse {
+  // SendInputMessageResponse headers
+  Headers headers = 1;
+}

--- a/proto/iotics/api/interest.proto
+++ b/proto/iotics/api/interest.proto
@@ -22,19 +22,19 @@ option php_namespace = "Iotics\\Api";
 
 // InterestAPI enables creation and management of interests between a twin and a feed.
 service InterestAPI {
-  // Fetch feed data for this interest.
+  // Fetch feed data for this interest. (local and remote)
   rpc FetchInterests(FetchInterestRequest) returns (stream FetchInterestResponse) {}
 
-  // Fetch last data shared on this interest.
+  // Fetch last data shared on this interest. (local and remote)
   rpc FetchLastStored(FetchLastStoredRequest) returns (FetchInterestResponse) {}
 
   // List all interests associated to a given follower twin (Not implemented yet).
   rpc ListAllInterests(ListAllInterestsRequest) returns (ListAllInterestsResponse) {}
 
-  // Create an interest between a follower twin and a followed feed.
+  // Create an interest between a follower twin and a followed feed. (Not implemented yet).
   rpc CreateInterest(CreateInterestRequest) returns (CreateInterestResponse) {}
 
-  // Delete an existing interest.
+  // Delete an existing interest. (Not implemented yet).
   rpc DeleteInterest(DeleteInterestRequest) returns (DeleteInterestResponse) {}
 
 }

--- a/proto/iotics/api/meta.proto
+++ b/proto/iotics/api/meta.proto
@@ -27,13 +27,13 @@ service MetaAPI {
   //   results (when performing a non-local query). See scope parameter in SparqlQueryRequest;
   // - The call will only complete once the (specified or host default) request timeout has been reached. The client can
   //   choose to end the stream early once they have received enough results. (E.g. in the case of Scope.LOCAL this
-  //   would be after the one and only sequence of chunks has been received.)
+  //   would be after the one and only sequence of chunks has been received.). (local and remote)
   rpc SparqlQuery(SparqlQueryRequest) returns (stream SparqlQueryResponse) {}
 
   // SparqlUpdate performs a SPARQL 1.1 update. When performing an update, the update query must contain a reference to 
   // one of the following graph IRIs:
   // 1. http://data.iotics.com/graph#custom-public (aka custom public graph) - All metadata written to this graph will be 
-  //    visible during SPARQL queries both with local & global scope (and thus, the Iotics network).
+  //    visible during SPARQL queries both with local & global scope (and thus, the Iotics network). (local only)
   rpc SparqlUpdate(SparqlUpdateRequest) returns (SparqlUpdateResponse) {}
 }
 

--- a/proto/iotics/api/search.proto
+++ b/proto/iotics/api/search.proto
@@ -23,13 +23,13 @@ option php_namespace = "Iotics\\Api";
 
 // SearchAPI provides a set of services to run synchronous and asynchronous search.
 service SearchAPI {
-  // Send a search request. Results are expected asynchronously.
+  // Send a search request. Results are expected asynchronously. (local and remote)
   rpc DispatchSearchRequest(SearchRequest) returns (DispatchSearchResponse) {}
 
-  // Run a synchronous search based on a user timeout.
+  // Run a synchronous search based on a user timeout. (local and remote)
   rpc SynchronousSearch(SearchRequest) returns (stream SearchResponse) {}
 
-  // Receive all search responses associated to a set of Search request for a given client application ID.
+  // Receive all search responses associated to a set of Search request for a given client application ID. (local only)
   rpc ReceiveAllSearchResponses(SubscriptionHeaders) returns (stream SearchResponse) {}
 }
 

--- a/proto/iotics/api/search.proto
+++ b/proto/iotics/api/search.proto
@@ -8,6 +8,7 @@ import "google/protobuf/timestamp.proto";
 import "google/rpc/status.proto";
 import "iotics/api/common.proto";
 import "iotics/api/feed.proto";
+import "iotics/api/input.proto";
 package iotics.api;
 
 option csharp_namespace = "Iotics.Api";
@@ -98,6 +99,13 @@ message SearchResponse {
     repeated Property properties = 4;
 
   }
+  // Search response input details. Included with response type: FULL.
+  message InputDetails {
+    // Input
+    Input input = 1;
+    // Input custom properties.
+    repeated Property properties = 4;
+  }
 
   // Search response twin details.
   message TwinDetails {
@@ -111,6 +119,8 @@ message SearchResponse {
     repeated Property properties = 5;
     // Feed details. Included with response type: FULL
     repeated FeedDetails feeds = 10;
+    // Feed details. Included with response type: FULL
+    repeated InputDetails inputs = 11;
   }
 
   Headers headers = 1;

--- a/proto/iotics/api/twin.proto
+++ b/proto/iotics/api/twin.proto
@@ -3,7 +3,6 @@
 // Iotics Web protocol definitions (twins)
 syntax = "proto3";
 
-import "google/protobuf/wrappers.proto";
 import "iotics/api/common.proto";
 import "iotics/api/feed.proto";
 
@@ -23,24 +22,24 @@ option php_namespace = "Iotics\\Api";
 // TwinAPI enables creation and management of Iotics twins.
 service TwinAPI {
 
-  // CreateTwin creates a twin.
+  // CreateTwin creates a twin. (local only)
   rpc CreateTwin(CreateTwinRequest) returns (CreateTwinResponse) {}
 
   // UpsertTwin creates or update a twin with its metadata + the twin feeds with their metadata.
   // The full state is applied (ie. if the operation succeeds the state of the twin/feeds will be the one
-  // described in the payload)
+  // described in the payload) (local only)
   rpc UpsertTwin(UpsertTwinRequest) returns (UpsertTwinResponse) {}
 
-  // DeleteTwin deletes a twin.
+  // DeleteTwin deletes a twin. (local only)
   rpc DeleteTwin(DeleteTwinRequest) returns (DeleteTwinResponse) {}
 
-  // UpdateTwin updates a twin (partial update).
+  // UpdateTwin updates a twin (partial update). (local only)
   rpc UpdateTwin(UpdateTwinRequest) returns (UpdateTwinResponse) {}
 
-  // Describes a twin.
+  // Describes a twin. (local and remote)
   rpc DescribeTwin(DescribeTwinRequest) returns (DescribeTwinResponse) {}
 
-  // List all twins.
+  // List all twins. (local only)
   rpc ListAllTwins(ListAllTwinsRequest) returns (ListAllTwinsResponse) {}
 }
 

--- a/proto/iotics/api/twin.proto
+++ b/proto/iotics/api/twin.proto
@@ -5,6 +5,7 @@ syntax = "proto3";
 
 import "iotics/api/common.proto";
 import "iotics/api/feed.proto";
+import "iotics/api/input.proto";
 
 package iotics.api;
 
@@ -173,15 +174,20 @@ message FeedMeta {
   bool storeLast = 3;
 }
 
+// Metadata message for this input.
+message InputMeta {
+  InputID inputId = 1;
+}
+
 // The response for a description request on this twin.
 message DescribeTwinResponse {
   Headers headers = 1;
-
 
   // Metadata result data bag for this feed.
   message MetaResult {
     GeoLocation location = 1;
     repeated FeedMeta feeds = 4;
+    repeated InputMeta inputs = 5;
     // Custom properties associated with this twin.
     repeated Property properties = 6;
   }
@@ -279,6 +285,9 @@ message UpsertTwinRequest {
 
     // Feeds with metadata to set to the twin
     repeated UpsertFeedWithMeta feeds = 7;
+
+    // Inputs with metadata to set to the twin
+    repeated UpsertInputWithMeta inputs = 8;
 
   }
   // UpdateTwinRequest headers


### PR DESCRIPTION
Scope: add minimal API entries to use input


EI-1103 - Small Cleanup    
* Remove Control from comments
* Remove legacy comment
* Remove Point type cleanup
* Add local/remote comment
* Make feed similar to input in terms of comments
* Remove unused import (see https://github.com/Iotic-Labs/api/issues/13)

EI-1103 - Specify Input
* delete
* describe
* send input message
* receive input messages
* upsert payload part

EI-1103 - Input: update existing services
* upsert: includes input meta in the UpsertTwinRequestPayload
* search: update SearchResponsePayload to include the input details
* describe twin: update DescribeTwinResponsePayload to include the input details


