### PR TITLE
ei-1172: canned explorer request

### DIFF
--- a/proto/iotics/api/common.proto
+++ b/proto/iotics/api/common.proto
@@ -101,9 +101,17 @@ message GeoCircle {
   double radiusKm = 2;
 }
 
-// Visibility defines who a twin is visible to.
-// PRIVATE - the twin is only visible in a LOCAL scope.
-// PUBLIC - the twin is visible in any scope.
+// DEPRECATED
+// This field will be temporarily maintained alongside the metadata network allowlist for backwards compatibility.
+// Going forward, the metadata network allowlist should be used instead.
+//
+// Read behaviour:
+// PRIVATE - the twin is only visible in a LOCAL scope or according to the metadata network allowlist
+// PUBLIC - the twin is visible in any scope. (ie. metadata network allowlist [ALLOW_ALL])
+//
+// Write behaviour:
+// PRIVATE - set the metadata network allowlist to ALLOW_NONE: the twin is only visible in a LOCAL scope
+// PUBLIC - set the metadata network allowlist to ALLOW_ALL: the twin is visible in any scope.
 enum Visibility {
   PRIVATE = 0;
   PUBLIC = 1;

--- a/proto/iotics/api/meta.proto
+++ b/proto/iotics/api/meta.proto
@@ -36,6 +36,32 @@ service MetaAPI {
   // 1. http://data.iotics.com/graph#custom-public (aka custom public graph) - All metadata written to this graph will be
   //    visible during SPARQL queries both with local & global scope (and thus, the Iotics network).
   rpc SparqlUpdate(SparqlUpdateRequest) returns (SparqlUpdateResponse) {}
+
+  // ExplorerQuery - Deprecated - use SparqlQuery instead.
+  rpc ExplorerQuery(ExplorerRequest) returns (stream SparqlQueryResponse) {}
+}
+
+// ExplorerRequest - Deprecated. Use SparqlQueryRequest instead.
+message ExplorerRequest {
+
+  // Explorer request payload.
+  message Payload {
+    // The desired result content type. Note that choosing an invalid result type for the type of query will result in
+    // an error status reported in the response. (See SparqlResultType for valid content-query type combinations.)
+    SparqlResultType resultContentType = 1;
+
+    // keyword defines the search term associated to the explorer request.
+    string keyword = 2;
+  }
+
+  // Explorer request headers
+  Headers headers = 1;
+
+  // Explorer request scope
+  Scope scope = 2;
+
+  // Explorer request payload
+  Payload payload = 3;
 }
 
 // SparqlResultType defines the result content types for SPARQL requests. Note that applicable content types depend on

--- a/proto/iotics/api/search.proto
+++ b/proto/iotics/api/search.proto
@@ -114,7 +114,7 @@ message SearchResponse {
     TwinID id = 1;
     // Twin location (if set). Included with response type: FULL and LOCATED
     GeoLocation location = 2;
-    // Twin visibility. Enum that defines a twins level of visibility.
+    // DEPRECATED - see field description for details.
     Visibility visibility = 3;
     // Twin custom properties.
     repeated Property properties = 5;

--- a/proto/iotics/api/twin.proto
+++ b/proto/iotics/api/twin.proto
@@ -52,7 +52,7 @@ message Twin {
   // Unique ID of the twin, assigned by the user.
   TwinID id = 1;
 
-  // Visibility of this twin
+  // DEPRECATED - see field description for details.
   Visibility visibility = 2;
 }
 
@@ -73,7 +73,7 @@ message ListAllTwinsResponse {
   message TwinDetails {
     // Twin identifier.
     TwinID id = 1;
-    // Twin visibility. Enum that defines a twins level of visibility.
+    // DEPRECATED - see field description for details.
     Visibility visibility = 2;
     // Twin location (if set).
     GeoLocation location = 3;
@@ -210,9 +210,9 @@ message DescribeTwinResponse {
 
 // ---------------------------------------
 
-// VisibilityUpdate describes the update of a twin visibility.
+// DEPRECATED - see Visibility field description for details.
 message VisibilityUpdate {
-  // New visibility for this twin
+  // DEPRECATED - see field description for details.
   Visibility visibility = 1;
 }
 
@@ -233,7 +233,7 @@ message UpdateTwinRequest {
   // Note that the specified metadata changes are applied in the following order:
   // tags, visibility, properties, labels, comments, location
   message Payload {
-    // New visibility
+    // DEPRECATED - see Visibility field description for details.
     VisibilityUpdate newVisibility = 2;
 
     // Custom properties to add/remove. Internal properties (such as location) cannot be modified here.
@@ -275,7 +275,10 @@ message UpsertTwinRequest {
     // Unique ID of the twin to create/update
     string twinId = 1;
 
-    // Twin visibility. Default value: 'PRIVATE'
+    // DEPRECATED - see field description for details.
+    // If any metadata network allowlist property is provided, the visibility value will be ignored.
+    //
+    // Default value: 'PRIVATE'
     Visibility visibility = 2;
 
     // Twin Properties to set


### PR DESCRIPTION
Adding new explorer service and request.

This will:
* be deprecated from day 1;
* temporarily host the canned sparql query required by explorer;
* allow injection of a keyword;
* return a SparqlQueryResponse, the same as the existing SparqlQueryRequest does - no changes to response processing

Visibility deprecation:
* deprecating Visibility field in requests/responses;
* documenting temporary backwards compatibility feature alignment with metadata network allowlist.