### PR TITLE
INITIAL CHANGES: API update to refactor twinId/hostId

### DIFF
--- a/proto/iotics/api/common.proto
+++ b/proto/iotics/api/common.proto
@@ -165,9 +165,9 @@ message SubscriptionHeaders {
 
 }
 
-// Twin is the virtual representation of a (physical, purely virtual or hybrid) device,
+// TwinID is the virtual representation of a (physical, purely virtual or hybrid) device,
 // is only ever located in the host it was created.
-message Twin {
+message TwinID {
   // Twin Identifier (using DID format)
   string id = 1;
   // Host Identifier (using DID format)

--- a/proto/iotics/api/common.proto
+++ b/proto/iotics/api/common.proto
@@ -165,16 +165,13 @@ message SubscriptionHeaders {
 
 }
 
-// HostID is a unique host identifier.
-message HostID {
-  // Host Identifier string representation
-  string value = 1;
-}
-
-// TwinID is a unique twin identifier.
-message TwinID {
+// Twin is the virtual representation of a (physical, purely virtual or hybrid) device,
+// is only ever located in the host it was created.
+message Twin {
   // Twin Identifier (using DID format)
-  string value = 1;
+  string id = 1;
+  // Host Identifier (using DID format)
+  string hostId = 2;
 }
 
 // FeedID is a unique feed identifier (scoped to the set of feeds for a TwinID).

--- a/proto/iotics/api/feed.proto
+++ b/proto/iotics/api/feed.proto
@@ -48,7 +48,7 @@ message Feed {
   // Feed identifier (unique within the scope of a twin identifier's feed set)
   FeedID id = 1;
   // Twin unique identifier (twin to which the feed belongs)
-  TwinID twinId = 2;
+  Twin twin = 2;
 }
 
 // CreateFeedRequestCreate is used to create a new feed in a given twin.
@@ -62,7 +62,7 @@ message CreateFeedRequest {
   // Arguments describes the mandatory arguments to identify the twin the feed belongs to.
   message Arguments {
     // Identifier of the twin owning this feed
-    TwinID twinId = 1;
+    Twin twin = 1;
   }
 
   // CreateFeedRequest headers
@@ -192,7 +192,7 @@ message ListAllFeedsRequest {
   // ListAllFeedsRequest mandatory arguments.
   message Arguments {
     // Identifier of the twin owning this feed
-    TwinID twinId = 1;
+    Twin twin = 1;
   }
 
   // ListAllFeedsRequest headers
@@ -225,8 +225,6 @@ message DescribeFeedRequest {
   message Arguments {
     // Feed to describe
     Feed feed = 1;
-    // HostID to describe a remote feed (Optional, keep empty if feed is local)
-    HostID remoteHostId = 2;
   }
 
   // DescribeFeedRequest headers
@@ -254,8 +252,6 @@ message DescribeFeedResponse {
     Feed feed = 1;
     // Metadata result
     MetaResult result = 2;
-    // HostID of the described feed. (Optional, empty if feed is local)
-    HostID remoteHostId = 3;
   }
 
   // DescribeFeedResponse headers

--- a/proto/iotics/api/feed.proto
+++ b/proto/iotics/api/feed.proto
@@ -48,7 +48,7 @@ message Feed {
   // Feed identifier (unique within the scope of a twin identifier's feed set)
   FeedID id = 1;
   // Twin unique identifier (twin to which the feed belongs)
-  Twin twin = 2;
+  TwinID twinId = 2;
 }
 
 // CreateFeedRequestCreate is used to create a new feed in a given twin.
@@ -62,7 +62,7 @@ message CreateFeedRequest {
   // Arguments describes the mandatory arguments to identify the twin the feed belongs to.
   message Arguments {
     // Identifier of the twin owning this feed
-    Twin twin = 1;
+    TwinID twinId = 1;
   }
 
   // CreateFeedRequest headers
@@ -192,7 +192,7 @@ message ListAllFeedsRequest {
   // ListAllFeedsRequest mandatory arguments.
   message Arguments {
     // Identifier of the twin owning this feed
-    Twin twin = 1;
+    TwinID twinId = 1;
   }
 
   // ListAllFeedsRequest headers

--- a/proto/iotics/api/input.proto
+++ b/proto/iotics/api/input.proto
@@ -37,7 +37,7 @@ message Input {
   // Input identifier (unique within the scope of a twin identifier's input set)
   InputID id = 1;
   // Twin unique identifier (twin to which the input belongs)
-  Twin twin = 2;
+  TwinID twinId = 2;
 }
 // ---------------------------------------
 

--- a/proto/iotics/api/input.proto
+++ b/proto/iotics/api/input.proto
@@ -37,7 +37,7 @@ message Input {
   // Input identifier (unique within the scope of a twin identifier's input set)
   InputID id = 1;
   // Twin unique identifier (twin to which the input belongs)
-  TwinID twinId = 2;
+  Twin twin = 2;
 }
 // ---------------------------------------
 
@@ -76,8 +76,6 @@ message DescribeInputRequest {
   message Arguments {
     // Input to describe
     Input input = 1;
-    // HostID to describe a remote input (Optional, keep empty if input is local)
-    HostID remoteHostId = 2;
   }
 
   // DescribeInputRequest headers
@@ -101,8 +99,6 @@ message DescribeInputResponse {
     Input input = 1;
     // Metadata result
     MetaResult result = 2;
-    // HostID of the described input. (Optional, empty if input is local)
-    HostID remoteHostId = 3;
   }
 
   // DescribeInputResponse headers

--- a/proto/iotics/api/interest.proto
+++ b/proto/iotics/api/interest.proto
@@ -49,11 +49,9 @@ message InputInterest {
   message DestinationInput {
     // Input to send the message to
     Input input = 1;
-    // HostID to identify a remote input (Optional, keep empty if input is local)
-    HostID hostId = 2;
   }
   // Sender twin unique identifier.
-  TwinID senderTwinId = 1;
+  Twin senderTwin = 1;
 
   // a reference to the input of interest
   DestinationInput destInput = 2;
@@ -94,16 +92,13 @@ message Interest {
   message FollowedFeed {
     // Followed feed identifier
     Feed feed = 1;
-    // Feed remote host identifier (If not specified, the Interest is taken to be in scope of the host from which a request is made.)
-    HostID hostId = 2;
   }
 
   // Follower twin unique identifier.
-  TwinID followerTwinId = 2;
+  Twin followerTwin = 2;
 
   // a reference to the interested feed
   FollowedFeed followedFeed = 3;
-
 }
 
 // CreateInterestRequest is used to create an interest between a twin and a feed.
@@ -115,7 +110,7 @@ message CreateInterestRequest {
   // CreateInterestRequest mandatory arguments.
   message Arguments {
     // Follower twin unique identifier
-    TwinID twinId = 1;
+    Twin twin = 1;
   }
 
   // CreateInterestRequest headers
@@ -149,7 +144,7 @@ message ListAllInterestsRequest {
   // ListAllInterestsRequest mandatory arguments.
   message Arguments {
     // Follower twin unique identifier
-    TwinID twinId = 1;
+    Twin twin = 1;
   }
 
   // ListAllInterestsRequest headers

--- a/proto/iotics/api/interest.proto
+++ b/proto/iotics/api/interest.proto
@@ -51,7 +51,7 @@ message InputInterest {
     Input input = 1;
   }
   // Sender twin unique identifier.
-  Twin senderTwin = 1;
+  TwinID senderTwinId = 1;
 
   // a reference to the input of interest
   DestinationInput destInput = 2;
@@ -95,7 +95,7 @@ message Interest {
   }
 
   // Follower twin unique identifier.
-  Twin followerTwin = 2;
+  TwinID followerTwinId = 2;
 
   // a reference to the interested feed
   FollowedFeed followedFeed = 3;
@@ -110,7 +110,7 @@ message CreateInterestRequest {
   // CreateInterestRequest mandatory arguments.
   message Arguments {
     // Follower twin unique identifier
-    Twin twin = 1;
+    TwinID twinId = 1;
   }
 
   // CreateInterestRequest headers
@@ -144,7 +144,7 @@ message ListAllInterestsRequest {
   // ListAllInterestsRequest mandatory arguments.
   message Arguments {
     // Follower twin unique identifier
-    Twin twin = 1;
+    TwinID twinId = 1;
   }
 
   // ListAllInterestsRequest headers

--- a/proto/iotics/api/meta.proto
+++ b/proto/iotics/api/meta.proto
@@ -107,7 +107,7 @@ message SparqlQueryRequest {
 
 // SparqlQueryResponse is a part of a result for a SPARQL query request. Multiple chunks form a complete result. Related
 // chunks can be identified by a combination of:
-// - The host ID (unset for local results)
+// - The hostId
 // - Client reference (in headers, set by caller)
 // - Chunk sequence number
 message SparqlQueryResponse {
@@ -117,7 +117,7 @@ message SparqlQueryResponse {
 
     // Result host identifier. Indicates from which host this result chunk came from. For a local result, this field
     // will be unset.
-    HostID remoteHostId = 1;
+    string hostId = 1;
 
     // Position of a chunk in result from a given host (and request). The first chunk has a sequence number of 0.
     uint64 seqNum = 2;
@@ -126,7 +126,7 @@ message SparqlQueryResponse {
     // requests can be identified by setting a unique clientRef in the request headers.
     bool last = 3;
 
-    // Result error status (only applicable to local results, i.e. when remoteHostId is unset). If set, this will
+    // Result error status (only applicable to local results). If set, this will
     // indicate a problem with running the query (e.g. invalid syntax or content type) as opposed to a more general
     // issue (in which case the standard gRPC error mechanism will be used and the stream terminated).
     google.rpc.Status status = 4;

--- a/proto/iotics/api/search.proto
+++ b/proto/iotics/api/search.proto
@@ -140,7 +140,7 @@ message SearchResponse {
   // Search response twin details.
   message TwinDetails {
     // Twin identifier. Included with response type: FULL, LOCATED and MINIMAL
-    Twin twin = 1;
+    TwinID twinId = 1;
     // Twin location (if set). Included with response type: FULL and LOCATED
     GeoLocation location = 2;
     // DEPRECATED - see field description for details.

--- a/proto/iotics/api/search.proto
+++ b/proto/iotics/api/search.proto
@@ -140,7 +140,7 @@ message SearchResponse {
   // Search response twin details.
   message TwinDetails {
     // Twin identifier. Included with response type: FULL, LOCATED and MINIMAL
-    TwinID id = 1;
+    Twin twin = 1;
     // Twin location (if set). Included with response type: FULL and LOCATED
     GeoLocation location = 2;
     // DEPRECATED - see field description for details.
@@ -164,8 +164,6 @@ message SearchResponse {
     ResponseType responseType = 1;
     // Response status - if present indicates that this response is invalid
     google.rpc.Status status = 2;
-    // Response host identifier - indicates from which host this response comes from
-    HostID remoteHostId = 4;
 
     // Matching twins
     repeated TwinDetails twins = 10;

--- a/proto/iotics/api/twin.proto
+++ b/proto/iotics/api/twin.proto
@@ -64,7 +64,7 @@ message ListAllTwinsResponse {
   // ListAllTwinsResponse twin details.
   message TwinDetails {
     // Twin identifier.
-    Twin twin = 1;
+    TwinID twinId = 1;
     // DEPRECATED - see field description for details.
     Visibility visibility = 2;
     // Twin location (if set).
@@ -89,7 +89,7 @@ message CreateTwinRequest {
   // Arguments identifies the twin to create.
   message Payload {
     // Unique ID of the twin to create
-    Twin twin = 1;
+    TwinID twinId = 1;
   }
 
   // Common headers
@@ -105,7 +105,7 @@ message CreateTwinResponse {
   // Payload identifies the twin which was created.
   message Payload {
     // Unique ID of the twin to delete
-    Twin twin = 1;
+    TwinID twinId = 1;
   }
 
   // Common headers
@@ -123,7 +123,7 @@ message DeleteTwinRequest {
   // Arguments identifies the twin to delete.
   message Arguments {
     // Unique ID of the twin to delete
-    Twin twin = 1;
+    TwinID twinId = 1;
   }
 
   // Common headers
@@ -139,7 +139,7 @@ message DeleteTwinResponse {
   // Payload identifies the twin which was deleted.
   message Payload {
     // Unique ID of the twin to delete
-    Twin twin = 1;
+    TwinID twinId = 1;
   }
 
   // Common headers
@@ -154,7 +154,7 @@ message DescribeTwinRequest {
   // Only one action argument is necessary.
   message Arguments {
     // Unique ID of the twin to describe
-    Twin twin = 1;
+    TwinID twinId = 1;
   }
 
   Headers headers = 1;
@@ -196,7 +196,7 @@ message DescribeTwinResponse {
   // Payload of described twins.
   message Payload {
     // the twin
-    Twin twin = 1;
+    TwinID twinId = 1;
 
     // the description details
     MetaResult result = 2;
@@ -224,7 +224,7 @@ message UpdateTwinRequest {
   // UpdateTwinRequest mandatory arguments.
   message Arguments {
     // Unique ID of the twin to update
-    Twin twin = 1;
+    TwinID twinId = 1;
   }
   // UpdateTwinRequest payload. One or more fields can be provided, depending on what needs to be updated.
   // Note that the specified metadata changes are applied in the following order:
@@ -255,7 +255,7 @@ message UpdateTwinResponse {
   // UpdateTwinResponse payload.
   message Payload {
     // Unique ID of the twin to delete
-    Twin twin = 1;
+    TwinID twinId = 1;
   }
   // UpdateTwinResponse headers
   Headers headers = 1;
@@ -270,7 +270,7 @@ message UpsertTwinRequest {
   message Payload {
 
     // Unique ID of the twin to create/update
-    Twin twin = 1;
+    TwinID twinId = 1;
 
     // DEPRECATED - see field description for details.
     // If any metadata network allowlist property is provided, the visibility value will be ignored.
@@ -304,7 +304,7 @@ message UpsertTwinResponse {
   // Payload identifies the twin which was created.
   message Payload {
     // Unique ID of the created/updated twin
-    Twin twin = 1;
+    TwinID twinId = 1;
   }
 
   // Common headers

--- a/proto/iotics/api/twin.proto
+++ b/proto/iotics/api/twin.proto
@@ -48,17 +48,6 @@ service TwinAPI {
   rpc ListAllTwins(ListAllTwinsRequest) returns (ListAllTwinsResponse) {}
 }
 
-// Twin is the virtual representation of a (physical, purely virtual or hybrid) device,
-// is only ever located in the host it was created.
-message Twin {
-
-  // Unique ID of the twin, assigned by the user.
-  TwinID id = 1;
-
-  // DEPRECATED - see field description for details.
-  Visibility visibility = 2;
-}
-
 // List all twins.
 message ListAllTwinsRequest {
   Headers headers = 1;
@@ -75,7 +64,7 @@ message ListAllTwinsResponse {
   // ListAllTwinsResponse twin details.
   message TwinDetails {
     // Twin identifier.
-    TwinID id = 1;
+    Twin twin = 1;
     // DEPRECATED - see field description for details.
     Visibility visibility = 2;
     // Twin location (if set).
@@ -100,7 +89,7 @@ message CreateTwinRequest {
   // Arguments identifies the twin to create.
   message Payload {
     // Unique ID of the twin to create
-    TwinID twinId = 1;
+    Twin twin = 1;
   }
 
   // Common headers
@@ -116,7 +105,7 @@ message CreateTwinResponse {
   // Payload identifies the twin which was created.
   message Payload {
     // Unique ID of the twin to delete
-    TwinID twinId = 1;
+    Twin twin = 1;
   }
 
   // Common headers
@@ -134,7 +123,7 @@ message DeleteTwinRequest {
   // Arguments identifies the twin to delete.
   message Arguments {
     // Unique ID of the twin to delete
-    TwinID twinId = 1;
+    Twin twin = 1;
   }
 
   // Common headers
@@ -150,7 +139,7 @@ message DeleteTwinResponse {
   // Payload identifies the twin which was deleted.
   message Payload {
     // Unique ID of the twin to delete
-    TwinID twinId = 1;
+    Twin twin = 1;
   }
 
   // Common headers
@@ -164,11 +153,8 @@ message DeleteTwinResponse {
 message DescribeTwinRequest {
   // Only one action argument is necessary.
   message Arguments {
-    // unique id of the twin to describe
-    TwinID twinId = 1;
-
-    // optional HostID to describe a remote twin
-    HostID remoteHostId = 2;
+    // Unique ID of the twin to describe
+    Twin twin = 1;
   }
 
   Headers headers = 1;
@@ -194,6 +180,8 @@ message DescribeTwinResponse {
   // Metadata result data bag for this feed.
   message MetaResult {
     GeoLocation location = 1;
+    // Deprecated - see field description for details.
+    Visibility visibility = 2;
     repeated FeedMeta feeds = 4;
     repeated InputMeta inputs = 5;
     // Custom properties associated with this twin.
@@ -212,9 +200,6 @@ message DescribeTwinResponse {
 
     // the description details
     MetaResult result = 2;
-
-    // optional - if present indicates this response comes from a remote host
-    HostID remoteHostId = 3;
   }
   Payload payload = 2;
 }
@@ -239,7 +224,7 @@ message UpdateTwinRequest {
   // UpdateTwinRequest mandatory arguments.
   message Arguments {
     // Unique ID of the twin to update
-    TwinID twinId = 1;
+    Twin twin = 1;
   }
   // UpdateTwinRequest payload. One or more fields can be provided, depending on what needs to be updated.
   // Note that the specified metadata changes are applied in the following order:
@@ -270,7 +255,7 @@ message UpdateTwinResponse {
   // UpdateTwinResponse payload.
   message Payload {
     // Unique ID of the twin to delete
-    TwinID twinId = 1;
+    Twin twin = 1;
   }
   // UpdateTwinResponse headers
   Headers headers = 1;
@@ -285,7 +270,7 @@ message UpsertTwinRequest {
   message Payload {
 
     // Unique ID of the twin to create/update
-    string twinId = 1;
+    Twin twin = 1;
 
     // DEPRECATED - see field description for details.
     // If any metadata network allowlist property is provided, the visibility value will be ignored.
@@ -318,8 +303,8 @@ message UpsertTwinResponse {
 
   // Payload identifies the twin which was created.
   message Payload {
-    // created/updated twin
-    string twinId = 1;
+    // Unique ID of the created/updated twin
+    Twin twin = 1;
   }
 
   // Common headers


### PR DESCRIPTION
**Breaking Changes:**
* Make composite `TwinID` object with twin id and hostId
* Remove value wrapping and migrate to use string fields
* Remove most occurrences of hostId/remoteHostId across API in favour of composite ID above