### PR TITLE
EI-1175 - Add filter(advanced) search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ BUF = docker run --volume "${PWD}:/workspace" --workdir /workspace bufbuild/buf:
 
 build: lint
 
+mod-update:
+	$(BUF) mod update
+
 list:
 	$(BUF) ls-files
 
@@ -13,4 +16,3 @@ lint:
 
 lint-with-buf-error-codes:
 	$(BUF) lint --error-format=config-ignore-yaml
-

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Protobuf definitions are under `proto/` directory.
 
 See <https://github.com/golang/protobuf> and <https://github.com/grpc-ecosystem/grpc-gateway>
 
+## Dependencies
+
+See the `deps:` section in `buf.yaml` regarding third-party dependencies. To update these, run:
+
+```shell
+make mod-update
+```
+
 ## Lint
 
 Validate proto files:

--- a/proto/iotics/api/search.proto
+++ b/proto/iotics/api/search.proto
@@ -108,9 +108,8 @@ message AdvancedSearchRequest {
   // Search request payload
   Payload payload = 3;
 
-  // Search result limit (optional), affecting the maximum number of twins returned, per host. If not specified, a host-
-  // configured maximum limit will be applied.
-  Limit limit = 4;
+  // Search request range
+  Range range = 20;
 }
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/proto/iotics/api/search.proto
+++ b/proto/iotics/api/search.proto
@@ -34,8 +34,8 @@ service SearchAPI {
   // Receive all search responses associated to a set of Search request for a given client application ID.
   rpc ReceiveAllSearchResponses(SubscriptionHeaders) returns (stream SearchResponse) {}
 
-  // Run a filter search request on a user timeout and return formatted results.
-  rpc FilterSearch(FilterSearchRequest) returns (stream SearchResponse) {}
+  // Run an advanced (filter) search request on a user timeout and return formatted results.
+  rpc AdvancedSearch(AdvancedSearchRequest) returns (stream SearchResponse) {}
 }
 
 // ResponseType describes the type of the search response.
@@ -86,9 +86,9 @@ message SearchRequest {
   Range range = 20;
 }
 
-// FilterSearchRequest describes a search request with more filtering possibilities than SearchRequest. It returns
+// AdvancedSearchRequest describes a search request with more filtering possibilities than SearchRequest. It returns
 // formatted details about the twins matched by the supplied filter.
-message FilterSearchRequest {
+message AdvancedSearchRequest {
   // Search request payload.
   message Payload {
 

--- a/proto/iotics/api/search.proto
+++ b/proto/iotics/api/search.proto
@@ -33,6 +33,9 @@ service SearchAPI {
 
   // Receive all search responses associated to a set of Search request for a given client application ID.
   rpc ReceiveAllSearchResponses(SubscriptionHeaders) returns (stream SearchResponse) {}
+
+  // Run a filter search request on a user timeout and return formatted results.
+  rpc FilterSearch(FilterSearchRequest) returns (stream SearchResponse) {}
 }
 
 // ResponseType describes the type of the search response.
@@ -56,7 +59,7 @@ message SearchRequest {
 
     // Search request filters, any of these can be used in combination or on their own.
     message Filter {
-      // Text filtering. One or more keywords which must match text from twin properies. Note that any (rather than all)
+      // Text filtering. One or more keywords which must match text from twin properties. Note that any (rather than all)
       // of the keywords will produce a match.
       google.protobuf.StringValue text = 1;
       // Location filtering: area within which twins must be located
@@ -81,6 +84,33 @@ message SearchRequest {
 
   // Search request range
   Range range = 20;
+}
+
+// FilterSearchRequest describes a search request with more filtering possibilities than SearchRequest. It returns
+// formatted details about the twins matched by the supplied filter.
+message FilterSearchRequest {
+  // Search request payload.
+  message Payload {
+
+    // Expected response type
+    ResponseType responseType = 1;
+
+    // The search filter, expressed as a JSON-encoded AST (in JSONLogic style)
+    string filter = 2;
+  }
+
+  // Search request headers
+  Headers headers = 1;
+
+  // Search request scope
+  Scope scope = 2;
+
+  // Search request payload
+  Payload payload = 3;
+
+  // Search result limit (optional), affecting the maximum number of twins returned, per host. If not specified, a host-
+  // configured maximum limit will be applied.
+  Limit limit = 4;
 }
 
 // ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Notes
~- Two commits:
    - One illustrates inclusion in existing search service
    - The other shows standalone new service
        - The existing search results format (`SearchResponse`) is still re-used, as is `ResponseType`)~
- Only the synchronous version (a la `SparqlQuery`) is supported initially
- ~`AdvancedSearchRawResponse` is similar to `SparqlQueryResponse`, except that it's more restrictive (fix return contents, i.e. not dynamically defined by user) and thus has its own definition.~ Now out of scope
- Unlike with existing search, there is no separate `expiryTimeout` since that is unused in the old search and timeouts are specified via the headers

## Questions
- Is "Advanced Search" a sensible name to use in the API? ~Set to "_Filter Search_" for now.~
- ~Do both formatted (`SearchResult`) and raw RDF responses need to be supported initially?~ No, only formatted