### PR TITLE
ei-1455: adding makefile targets for copying grpc health proto source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,3 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
 on:

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,28 @@ BUF_VERSION:=1.5.0
 GOPATH=$(shell go env GOPATH)
 BUF = docker run --volume "${PWD}:/workspace" --workdir /workspace bufbuild/buf:${BUF_VERSION}
 
+GRPC_PROTO_REPO = https://raw.githubusercontent.com/grpc/grpc-proto
+GRPC_PROTO_BRANCH = /master
+GRPC_PROTO_HEALTH_DIR = /grpc/health/v1
+GRPC_PROTO_HEALTH_PROTO = /health.proto
+
+IOTICS_PROTO_PATH = ./proto
+IOTICS_HEALTH_PROTO_FILE  = $(IOTICS_PROTO_PATH)$(GRPC_PROTO_HEALTH_DIR)$(GRPC_PROTO_HEALTH_PROTO)
+
 build: lint
 
 mod-update:
 	$(BUF) mod update
+
+health-proto-update: health-proto-clean $(IOTICS_HEALTH_PROTO_FILE)
+
+health-proto-clean:
+	@rm -rf $(IOTICS_PROTO_PATH)$(GRPC_PROTO_HEALTH_DIR)
+
+$(IOTICS_HEALTH_PROTO_FILE):
+	@mkdir -p $(IOTICS_PROTO_PATH)$(GRPC_PROTO_HEALTH_DIR)
+	@curl -sSL $(GRPC_PROTO_REPO)$(GRPC_PROTO_BRANCH)$(GRPC_PROTO_HEALTH_DIR)$(GRPC_PROTO_HEALTH_PROTO) > \
+		$(IOTICS_HEALTH_PROTO_FILE)
 
 list:
 	$(BUF) ls-files
@@ -16,3 +34,5 @@ lint:
 
 lint-with-buf-error-codes:
 	$(BUF) lint --error-format=config-ignore-yaml
+
+.PHONY: build mod-update health-proto-update health-proto-clean list lint lint-with-buf-error-codes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Iotics API
 
-Create Data Mesh. Use interoperable digital twins to create data interactions and build powerful real-time data products. This repository contains protocol buffers specification for Iotics API.
+This repository contains protocol buffer specifications for the Iotics API.
 
 The build pipeline is using [Buf](https://docs.buf.build)
 
@@ -8,7 +8,7 @@ The build pipeline is using [Buf](https://docs.buf.build)
 
 Protobuf definitions are under `proto/` directory.
 
-See <https://github.com/golang/protobuf> and <https://github.com/grpc-ecosystem/grpc-gateway>
+See [golang/protobuf](https://github.com/golang/protobuf) and [grpc-ecosystem/grpc-gateway](https://github.com/grpc-ecosystem/grpc-gateway)
 
 ## Dependencies
 
@@ -18,6 +18,16 @@ See the `deps:` section in `buf.yaml` regarding third-party dependencies. To upd
 make mod-update
 ```
 
+## Health Check
+
+> See [grpc/grpc-proto](https://github.com/grpc/grpc-proto)
+
+To include a copy of the canonical gRPC health check proto, run:
+
+```shell
+make health-proto-update
+```
+
 ## Lint
 
 Validate proto files:
@@ -25,6 +35,7 @@ Validate proto files:
 ```shell
 make lint
 ```
+
 
 ## Prerequisites
 

--- a/proto/grpc/health/v1/health.proto
+++ b/proto/grpc/health/v1/health.proto
@@ -1,0 +1,63 @@
+// Copyright 2015 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The canonical version of this proto can be found at
+// https://github.com/grpc/grpc-proto/blob/master/grpc/health/v1/health.proto
+
+syntax = "proto3";
+
+package grpc.health.v1;
+
+option csharp_namespace = "Grpc.Health.V1";
+option go_package = "google.golang.org/grpc/health/grpc_health_v1";
+option java_multiple_files = true;
+option java_outer_classname = "HealthProto";
+option java_package = "io.grpc.health.v1";
+
+message HealthCheckRequest {
+  string service = 1;
+}
+
+message HealthCheckResponse {
+  enum ServingStatus {
+    UNKNOWN = 0;
+    SERVING = 1;
+    NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3;  // Used only by the Watch method.
+  }
+  ServingStatus status = 1;
+}
+
+service Health {
+  // If the requested service is unknown, the call will fail with status
+  // NOT_FOUND.
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+
+  // Performs a watch for the serving status of the requested service.
+  // The server will immediately send back a message indicating the current
+  // serving status.  It will then subsequently send a new message whenever
+  // the service's serving status changes.
+  //
+  // If the requested service is unknown when the call is received, the
+  // server will send a message setting the serving status to
+  // SERVICE_UNKNOWN but will *not* terminate the call.  If at some
+  // future point, the serving status of the service becomes known, the
+  // server will send a new message with the service's serving status.
+  //
+  // If the call terminates with status UNIMPLEMENTED, then clients
+  // should assume this method is not supported and should not retry the
+  // call.  If the call terminates with any other status (including OK),
+  // clients should retry the call with appropriate exponential backoff.
+  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}


### PR DESCRIPTION
* clean up makefile/readme
* add make targets for copying source health proto from grpc repository